### PR TITLE
fix: 팝업 내 아이콘 드래그 시 이미지가 열리는 현상 수정

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,3 +20,6 @@
 - [ ] 코드 스타일 가이드를 준수했나요?
 - [ ] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
 - [ ] 문서(Wiki, API Docs 등)를 업데이트했나요?
+
+<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
+<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->

--- a/src/data.js
+++ b/src/data.js
@@ -614,7 +614,7 @@ const MASTER_SITE_LIST = [
     category: "학과",
   },
   {
-    id: "",
+    id: "cbam",
     name: "융합바이오 신소재공학과",
     url: "https://cbam.khu.ac.kr/bio/user/main/view.do",
     imgSrc: "images/portal.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "LinKHU",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "경희대학교 주요 웹서비스 바로가기, LinKHU",
   "action": {
     "default_popup": "popup.html",
@@ -20,14 +20,5 @@
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true
-  },
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "{7d6a54b3-2e1a-4f8a-96d0-1b2c3d4e5f6a}",
-      "strict_min_version": "140.0",
-      "data_collection_permissions": {
-        "required": ["none"]
-      }
-    }
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,5 +20,14 @@
   "options_ui": {
     "page": "options.html",
     "open_in_tab": true
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{7d6a54b3-2e1a-4f8a-96d0-1b2c3d4e5f6a}",
+      "strict_min_version": "140.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
+    }
   }
 }

--- a/src/popup.js
+++ b/src/popup.js
@@ -32,11 +32,9 @@ const App = {
     // 클릭 이벤트 처리
     el.addEventListener("click", (e) => {
       e.preventDefault(); // a 태그 기본 이동 방지
-      if (e.button === 0) {
-        const isBackground = e.ctrlKey || e.metaKey;
-        chrome.tabs.create({ url: item.url, active: !isBackground });
-        if (!isBackground) window.close();
-      }
+      const isBackground = e.ctrlKey || e.metaKey;
+      chrome.tabs.create({ url: item.url, active: !isBackground });
+      if (!isBackground) window.close();
     });
 
     // 휠클릭 이벤트 처리

--- a/src/popup.js
+++ b/src/popup.js
@@ -6,13 +6,15 @@
 const App = {
   // 1. [함수] 사이트 버튼(카드) 하나하나를 만드는 공장
   createCardItem(item) {
-    const el = document.createElement("div");
+    const el = document.createElement("a");
     el.className = "grid-item"; // CSS 적용을 위한 클래스명
+    el.href = item.url;
 
     // 이미지(로고) 생성
     const img = document.createElement("img");
     img.src = item.imgSrc;
     img.alt = item.name;
+    img.draggable = false; // 이미지 자체 드래그 방지, a 태그의 링크 드래그 유도
 
     // 이미지 로드 실패 시: 엑스박스 대신 기본 아이콘 보여주기
     img.onerror = () => {
@@ -28,12 +30,18 @@ const App = {
     el.appendChild(span);
 
     // 클릭 이벤트 처리
-    el.addEventListener("mouseup", (e) => {
+    el.addEventListener("click", (e) => {
+      e.preventDefault(); // a 태그 기본 이동 방지
       if (e.button === 0) {
-        // [좌클릭] 현재 탭을 해당 사이트로 이동
-        chrome.tabs.update({ url: item.url });
+        // [좌클릭] 새 탭을 해당 사이트로 이동
+        chrome.tabs.create({ url: item.url });
         window.close(); // 이동 후 팝업창 닫기 (깔끔함!)
-      } else if (e.button === 1) {
+      }
+    });
+
+    // 휠클릭 이벤트 처리
+    el.addEventListener("auxclick", (e) => {
+      if (e.button === 1) {
         // [휠클릭] 새 탭을 백그라운드에서 열기
         e.preventDefault();
         chrome.tabs.create({ url: item.url, active: false });

--- a/src/popup.js
+++ b/src/popup.js
@@ -33,9 +33,9 @@ const App = {
     el.addEventListener("click", (e) => {
       e.preventDefault(); // a 태그 기본 이동 방지
       if (e.button === 0) {
-        // [좌클릭] 새 탭을 해당 사이트로 이동
-        chrome.tabs.create({ url: item.url });
-        window.close(); // 이동 후 팝업창 닫기 (깔끔함!)
+        const isBackground = e.ctrlKey || e.metaKey;
+        chrome.tabs.create({ url: item.url, active: !isBackground });
+        if (!isBackground) window.close();
       }
     });
 


### PR DESCRIPTION
## 📝 요약
> 팝업 내 아이콘 드래그 시 이미지가 열리는 현상 수정 및 사이트 이동 기능 풀 추가

## ⚙️ 작업 사항
- [x] 사이트 아이콘(이미지) 요소의 자체 드래그 동작을 방지(draggable=false)
- [x] 마우스 드래그 시 이미지가 아닌 부모 요소(a 태그)의 링크 URL이 정상적으로 잡히도록 동작 개선
- [x] 사이트 아이콘 좌클릭 시 기존 탭에서 열기가 아닌 새 탭으로 열기로 변경
- [x] Ctrl(Cmd) + 클릭 시 백그라운드 탭에서 열기 기능 추가

## 📌 관련 이슈
- Close #1 

## 🧪 테스트 결과
> 작업한 내용이 의도대로 동작하는지 확인한 결과(스크린샷, 로그 등)를 첨부해주세요.
<img width="416" height="477" alt="스크린샷 2026-04-05 13 21 49(2)" src="https://github.com/user-attachments/assets/a0e36396-21c0-46fb-bec4-bb610f2f5ae5" />

## 💡 리뷰 포인트
- 이 부분의 로직이 최선일까요?
- 성능상 문제가 될 만한 부분이 있을까요?

## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했나요?
- [ ] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [ ] 문서(Wiki, API Docs 등)를 업데이트했나요?

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->