### PR TITLE
feat: 공통 서비스 바로가기 추가

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -119,6 +119,20 @@ const MASTER_SITE_LIST = [
     imgSrc: "images/portal.png",
     category: "공통",
   },
+  {
+    id: "oia",
+    name: "국제교류팀",
+    url: "https://oia.khu.ac.kr/oiak_kor/user/main/view.do",
+    imgSrc: "images/portal.png",
+    category: "공통",
+  },
+  {
+    id: "isss",
+    name: "글로벌교육지원팀",
+    url: "https://isss.khu.ac.kr/globalcenter/user/main/view.do",
+    imgSrc: "images/portal.png",
+    category: "공통",
+  },
 
   // 단과대
   {


### PR DESCRIPTION
## 📝 요약
> 공통 서비스 목록에 국제교류팀과 글로벌교육지원팀 바로가기를 추가합니다.

## ⚙️ 작업 사항
- [x] 국제교류팀 바로가기 추가
- [x] 글로벌교육지원팀 바로가기 추가
- [x] 기존 공통 서비스 데이터 구조 유지

## 📌 관련 이슈
- Close #9

## 🧪 테스트 결과
> `src/data.js` 로딩 후 데이터 검증을 수행했습니다.

- 총 사이트 수: 113개
- 중복 id: 0개
- 누락 필드: 0개
- 잘못된 카테고리: 0개
- 누락 이미지: 0개

## 💡 리뷰 포인트
- 두 사이트를 공통 서비스 카테고리에 추가하는 것이 적절한지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요?

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->