### PR TITLE
docs: README 지표 배지 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 <p>
   <a href="https://github.com/kangkyunghyun/LinKHU/releases/latest"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/kangkyunghyun/LinKHU?style=flat-square&logo=github&label=release"></a>
-  <a href="./LICENSE"><img alt="License" src="https://img.shields.io/github/license/kangkyunghyun/LinKHU?style=flat-square"></a>
+  <a href="./LICENSE"><img alt="GitHub License" src="https://img.shields.io/github/license/kangkyunghyun/LinKHU?style=flat-square&logo=github"></a>
   <a href="https://chromewebstore.google.com/detail/ihidkmjkpfphgljieecfcikljaopcldp"><img alt="Chrome Web Store Users" src="https://img.shields.io/chrome-web-store/users/ihidkmjkpfphgljieecfcikljaopcldp?style=flat-square&logo=googlechrome&label=chrome%20users"></a>
-  <a href="https://chromewebstore.google.com/detail/ihidkmjkpfphgljieecfcikljaopcldp"><img alt="Chrome Web Store Version" src="https://img.shields.io/chrome-web-store/v/ihidkmjkpfphgljieecfcikljaopcldp?style=flat-square&logo=googlechrome&label=chrome"></a>
+  <a href="https://chromewebstore.google.com/detail/ihidkmjkpfphgljieecfcikljaopcldp"><img alt="Chrome Web Store Version" src="https://img.shields.io/chrome-web-store/v/ihidkmjkpfphgljieecfcikljaopcldp?style=flat-square&logo=googlechrome&label=chrome%20version"></a>
   <a href="https://chromewebstore.google.com/detail/ihidkmjkpfphgljieecfcikljaopcldp"><img alt="Chrome Web Store Rating" src="https://img.shields.io/chrome-web-store/rating/ihidkmjkpfphgljieecfcikljaopcldp?style=flat-square&logo=googlechrome&label=chrome%20rating"></a>
   <a href="https://addons.mozilla.org/ko/firefox/addon/linkhu"><img alt="Firefox Add-ons Users" src="https://img.shields.io/amo/users/linkhu?style=flat-square&logo=firefoxbrowser&label=firefox%20users"></a>
-  <a href="https://addons.mozilla.org/ko/firefox/addon/linkhu"><img alt="Firefox Add-ons Version" src="https://img.shields.io/amo/v/linkhu?style=flat-square&logo=firefoxbrowser&label=firefox"></a>
+  <a href="https://addons.mozilla.org/ko/firefox/addon/linkhu"><img alt="Firefox Add-ons Version" src="https://img.shields.io/amo/v/linkhu?style=flat-square&logo=firefoxbrowser&label=firefox%20version"></a>
   <a href="https://addons.mozilla.org/ko/firefox/addon/linkhu"><img alt="Firefox Add-ons Weekly Downloads" src="https://img.shields.io/amo/dw/linkhu?style=flat-square&logo=firefoxbrowser&label=firefox%20downloads"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 경희대학교 학생들이 자주 사용하는 핵심 웹서비스들을 클릭 한 번으로 즉시 이동하세요.  
 
+<p>
+  <a href="https://github.com/kangkyunghyun/LinKHU/releases/latest"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/kangkyunghyun/LinKHU?style=flat-square&logo=github&label=release"></a>
+  <a href="./LICENSE"><img alt="License" src="https://img.shields.io/github/license/kangkyunghyun/LinKHU?style=flat-square"></a>
+  <a href="https://chromewebstore.google.com/detail/ihidkmjkpfphgljieecfcikljaopcldp"><img alt="Chrome Web Store Users" src="https://img.shields.io/chrome-web-store/users/ihidkmjkpfphgljieecfcikljaopcldp?style=flat-square&logo=googlechrome&label=chrome%20users"></a>
+  <a href="https://chromewebstore.google.com/detail/ihidkmjkpfphgljieecfcikljaopcldp"><img alt="Chrome Web Store Version" src="https://img.shields.io/chrome-web-store/v/ihidkmjkpfphgljieecfcikljaopcldp?style=flat-square&logo=googlechrome&label=chrome"></a>
+  <a href="https://chromewebstore.google.com/detail/ihidkmjkpfphgljieecfcikljaopcldp"><img alt="Chrome Web Store Rating" src="https://img.shields.io/chrome-web-store/rating/ihidkmjkpfphgljieecfcikljaopcldp?style=flat-square&logo=googlechrome&label=chrome%20rating"></a>
+  <a href="https://addons.mozilla.org/ko/firefox/addon/linkhu"><img alt="Firefox Add-ons Users" src="https://img.shields.io/amo/users/linkhu?style=flat-square&logo=firefoxbrowser&label=firefox%20users"></a>
+  <a href="https://addons.mozilla.org/ko/firefox/addon/linkhu"><img alt="Firefox Add-ons Version" src="https://img.shields.io/amo/v/linkhu?style=flat-square&logo=firefoxbrowser&label=firefox"></a>
+  <a href="https://addons.mozilla.org/ko/firefox/addon/linkhu"><img alt="Firefox Add-ons Weekly Downloads" src="https://img.shields.io/amo/dw/linkhu?style=flat-square&logo=firefoxbrowser&label=firefox%20downloads"></a>
+</p>
+
 [![Chrome Web Store](./docs/chrome-web-store.png)](https://chromewebstore.google.com/detail/ihidkmjkpfphgljieecfcikljaopcldp)
 [![Naver Whale Store](./docs/whalestore-sm.png)](https://store.whale.naver.com/detail/njhgalaophlilmhapklabocladclmhoc)
 [![Firefox Add-ons](./docs/firefox-sm.png)](https://addons.mozilla.org/ko/firefox/addon/linkhu)


### PR DESCRIPTION
## 작업 내용
- README 상단에 Shields.io 기반 GitHub release/license 배지를 추가했습니다.
- Chrome Web Store 사용자 수, 버전, 평점 배지를 추가했습니다.
- Firefox Add-ons 사용자 수, 버전, 주간 다운로드 배지를 추가했습니다.

## 확인
- git diff --check
- Shields.io endpoint 200 응답 확인: Chrome users/version/rating, Firefox users/version/downloads, GitHub release/license

Closes #15