### PR TITLE
refactor: 옵션 페이지 DOM 렌더링 개선

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -68,16 +68,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const icon = document.createElement("img");
     icon.src = site.imgSrc;
-    icon.alt = "icon";
+    icon.alt = "";
     icon.draggable = false;
 
     const siteName = document.createElement("span");
     siteName.className = "site-name";
     siteName.textContent = site.name.replace(/\s+/g, "");
 
-    el.appendChild(dragHandle);
-    el.appendChild(icon);
-    el.appendChild(siteName);
+    el.append(dragHandle, icon, siteName);
 
     addDragEvents(el); // 아이템에 드래그 기능 심어주기
     return el;

--- a/src/options.js
+++ b/src/options.js
@@ -61,11 +61,24 @@ document.addEventListener("DOMContentLoaded", () => {
     el.draggable = true; // 드래그 가능하게 설정
     el.dataset.id = site.id;
     el.dataset.category = site.category;
-    el.innerHTML = `
-      <div class="drag-handle">≡</div>
-      <img src="${site.imgSrc}" alt="icon" draggable="false">
-      <span class="site-name">${site.name.replace(/\s+/g, "")}</span>
-    `;
+
+    const dragHandle = document.createElement("div");
+    dragHandle.className = "drag-handle";
+    dragHandle.textContent = "≡";
+
+    const icon = document.createElement("img");
+    icon.src = site.imgSrc;
+    icon.alt = "icon";
+    icon.draggable = false;
+
+    const siteName = document.createElement("span");
+    siteName.className = "site-name";
+    siteName.textContent = site.name.replace(/\s+/g, "");
+
+    el.appendChild(dragHandle);
+    el.appendChild(icon);
+    el.appendChild(siteName);
+
     addDragEvents(el); // 아이템에 드래그 기능 심어주기
     return el;
   }


### PR DESCRIPTION
## 작업 내용
- 옵션 페이지 리스트 아이템 생성을 innerHTML 템플릿에서 DOM API 기반 생성으로 변경했습니다.
- 사이트 이름은 textContent로, 이미지 경로는 img.src 속성으로 설정하도록 분리했습니다.
- 기존 drag handle, icon, site-name 구조와 드래그 이벤트 연결은 유지했습니다.

## 확인
- node --check src/options.js
- git diff --check
- rg -n "innerHTML|insertAdjacentHTML|outerHTML" src/options.js 결과 없음

Closes #17