### PR TITLE
feat: GitHub Release 자동 생성 워크플로우 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Verify tag matches manifest version
+        run: |
+          manifest_version="$(node -p "require('./src/manifest.json').version")"
+          tag_version="${GITHUB_REF_NAME#v}"
+
+          if [ "$manifest_version" != "$tag_version" ]; then
+            echo "Tag version v$tag_version does not match manifest version v$manifest_version."
+            exit 1
+          fi
+
+      - name: Build extension package
+        run: npm run build
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            dist/*.zip \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ npm run build
 - `npm run package`: `src/`를 `dist/linkhu-v{manifest.version}.zip`으로 패키징합니다.
 - `npm run build`: 데이터 검증 후 패키징까지 한 번에 실행합니다.
 
+## 🚢 릴리스
+
+`src/manifest.json`의 `version`과 같은 버전 태그를 push하면 GitHub Release가 자동 생성됩니다.
+
+```bash
+VERSION=$(node -p "require('./src/manifest.json').version")
+git tag "v$VERSION"
+git push origin "v$VERSION"
+```
+
+릴리스 워크플로우는 `npm run build`로 패키징한 ZIP 파일을 첨부하고, 이전 릴리스 이후 변경 사항을 자동으로 생성합니다.
+
 ## 🐛 버그 제보 및 기여
 사이트 추가 또는 서비스 개선 등 Issue와 Pull Request를 통한 버그 제보 및 새로운 기능 제안은 언제나 환영입니다!
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ npm run build
 
 ## 🚢 릴리스
 
-`src/manifest.json`의 `version`과 같은 버전 태그를 push하면 GitHub Release가 자동 생성됩니다.
+릴리스 준비 PR에서 `src/manifest.json`의 `version`을 수정하고 `main`에 머지한 뒤, 같은 버전 태그를 push하면 GitHub Release가 자동 생성됩니다.
 
 ```bash
+git switch main
+git pull --ff-only
 VERSION=$(node -p "require('./src/manifest.json').version")
 git tag "v$VERSION"
 git push origin "v$VERSION"


### PR DESCRIPTION
## 📝 요약
> 버전 태그 push 시 GitHub Release를 자동 생성하고, 패키징된 확장 프로그램 ZIP과 자동 릴리스 노트를 함께 게시합니다.

## ⚙️ 작업 사항
- [x] v*.*.* 태그 push에서 실행되는 Release 워크플로우 추가
- [x] 태그 버전과 src/manifest.json version 일치 여부 검증
- [x] npm run build 실행 후 dist/*.zip을 GitHub Release asset으로 첨부
- [x] gh release create --generate-notes로 이전 릴리스 이후 변경 사항 자동 생성
- [x] README에 릴리스 태그 생성 절차 문서화

## 📌 관련 이슈
- Close #23

## 🧪 테스트 결과
- npm run build
  - 데이터 검증: 113 sites 통과, HTTP URL 경고 18개 유지
  - 패키징: dist/linkhu-v2.2.0.zip 생성, 21 files 포함
- unzip -t dist/linkhu-v2.2.0.zip
  - No errors detected
- git diff --check
  - 통과
- ruby YAML 파싱 확인
  - .github/workflows/release.yml 파싱 통과

## 💡 리뷰 포인트
- 릴리스 트리거를 v*.*.* 태그 push로 제한한 범위가 적절한지 확인 부탁드립니다.
- 태그 버전과 manifest 버전 불일치 시 실패시키는 정책이 릴리스 운영에 적절한지 확인 부탁드립니다.
- GitHub 자동 릴리스 노트(--generate-notes)를 사용하는 방식이 충분한지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] src/data.js 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요?

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->