### PR TITLE
docs: 스토어 배포 체크리스트 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ PR: feat: 공통 서비스 바로가기 추가
 - 릴리스 노트는 사용자에게 보이는 변경 사항 중심으로 작성한다.
 - 릴리스 준비 PR이 머지된 뒤 같은 버전 태그를 push한다.
 - 버전 태그 push는 GitHub Release와 ZIP 첨부만 자동화한다.
-- Chrome, Firefox, Whale 스토어 배포는 별도 작업으로 다룬다.
+- Chrome, Firefox, Whale 스토어 배포는 별도 작업으로 다루며 `docs/store-release-checklist.md`를 따른다.
 
 ## 수동 검증 기준
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ git push origin "v$VERSION"
 
 릴리스 워크플로우는 `npm run build`로 패키징한 ZIP 파일을 첨부하고, `release-notes/v{version}.md` 내용을 릴리스 노트로 사용합니다.
 
+스토어 배포는 [스토어 배포 체크리스트](./docs/store-release-checklist.md)를 따릅니다.
+
 ## 🐛 버그 제보 및 기여
 사이트 추가 또는 서비스 개선 등 Issue와 Pull Request를 통한 버그 제보 및 새로운 기능 제안은 언제나 환영입니다!
 

--- a/docs/store-release-checklist.md
+++ b/docs/store-release-checklist.md
@@ -35,7 +35,7 @@ LinKHU 스토어 배포는 GitHub Release에 첨부된 ZIP 파일을 기준으�
 - 새 패키지로 `linkhu-v{version}.zip`을 업로드한다.
 - 업로드 후 표시되는 manifest 정보와 버전을 확인한다.
 - 권한 변경, 개인정보 처리, 심사용 안내가 필요한지 확인한다.
-- Store Listing, Privacy, Distribution 정보 변경 필요 여부를 확인한다.
+- Store Listing(What's new 포함), Privacy, Distribution 정보 변경 필요 여부를 확인한다.
 - 제출 전 미리보기와 경고 메시지를 확인한다.
 - `Submit for Review`로 제출한다.
 - 제출 후 심사 상태와 게시 상태를 기록한다.
@@ -54,10 +54,10 @@ LinKHU 스토어 배포는 GitHub Release에 첨부된 ZIP 파일을 기준으�
 
 ## Naver Whale Store
 
-- [Whale Store](https://store.whale.naver.com/)에 로그인한다.
+- [Whale Store 개발자 센터](https://store.whale.naver.com/developers)에 접속하여 로그인한다.
 - My extensions 또는 개발자 관리 화면에서 LinKHU 항목으로 이동한다.
 - 새 패키지로 `linkhu-v{version}.zip`을 업로드한다.
-- 필수 정보, 권한, 심사용 설명을 확인한다.
+- 필수 정보, 권한, 심사용 설명 및 버전 설명(`release-notes/v{version}.md` 내용 활용)을 확인한다.
 - 스토어 설명, 스크린샷, 카테고리 변경 필요 여부를 확인한다.
 - 제출 전 경고 메시지를 확인한다.
 - 심사를 제출한다.

--- a/docs/store-release-checklist.md
+++ b/docs/store-release-checklist.md
@@ -1,0 +1,80 @@
+# Store Release Checklist
+
+LinKHU 스토어 배포는 GitHub Release에 첨부된 ZIP 파일을 기준으로 진행한다.
+
+## 참고 문서
+
+- Chrome Web Store: [Publish in the Chrome Web Store](https://developer.chrome.com/webstore/publish)
+- Chrome Web Store: [Prepare your extension](https://developer.chrome.com/docs/webstore/prepare/)
+- Firefox Add-ons: [Submitting an add-on](https://extensionworkshop.com/documentation/publish/submitting-an-add-on/)
+- Firefox Add-ons: [Signing and distributing your add-on](https://extensionworkshop.com/documentation/publish/signing-and-distribution-overview/)
+- Whale Store: [Add my extensions](https://help.whale.naver.com/en/desktop/store/)
+
+## 전제 조건
+
+- GitHub Release가 생성되어 있다.
+- Release tag와 `src/manifest.json`의 `version`이 일치한다.
+- Release asset에 `linkhu-v{version}.zip`이 첨부되어 있다.
+- Release notes가 `release-notes/v{version}.md` 내용과 일치한다.
+- Chrome, Firefox, Whale 스토어 관리자 계정에 접근할 수 있다.
+
+## 공통 배포 전 확인
+
+- GitHub Release 페이지에서 `linkhu-v{version}.zip`을 다운로드한다.
+- ZIP 파일명이 Release tag와 일치하는지 확인한다.
+- ZIP 파일을 압축 해제해 `manifest.json`이 최상위에 있는지 확인한다.
+- 압축 해제한 `manifest.json`의 `version`이 Release tag와 일치하는지 확인한다.
+- Release notes에서 사용자에게 보여줄 변경 사항을 확인한다.
+- 권한 변경이 있는지 `manifest.json`의 `permissions`, `host_permissions`, `browser_specific_settings`를 확인한다.
+- 스토어 설명, 스크린샷, 개인정보 처리 관련 답변을 수정해야 하는지 확인한다.
+
+## Chrome Web Store
+
+- [Chrome Developer Dashboard](https://chrome.google.com/webstore/devconsole)에 접속한다.
+- LinKHU 아이템을 선택한다.
+- 새 패키지로 `linkhu-v{version}.zip`을 업로드한다.
+- 업로드 후 표시되는 manifest 정보와 버전을 확인한다.
+- 권한 변경, 개인정보 처리, 심사용 안내가 필요한지 확인한다.
+- Store Listing, Privacy, Distribution 정보 변경 필요 여부를 확인한다.
+- 제출 전 미리보기와 경고 메시지를 확인한다.
+- `Submit for Review`로 제출한다.
+- 제출 후 심사 상태와 게시 상태를 기록한다.
+
+## Firefox Add-ons
+
+- [Add-ons Developer Hub](https://addons.mozilla.org/developers/)에 접속한다.
+- 기존 LinKHU add-on 관리 페이지로 이동한다.
+- 새 버전으로 `linkhu-v{version}.zip`을 업로드한다.
+- AMO validator 결과를 확인하고, error가 있으면 제출하지 않는다.
+- warning이 있으면 보안, 개인정보, 호환성 관련 경고인지 확인한다.
+- 릴리스 노트에는 `release-notes/v{version}.md` 내용을 사용한다.
+- source code package 제출이 필요한지 확인한다.
+- `Submit Version`으로 제출한다.
+- 제출 후 서명, 심사, 게시 상태를 기록한다.
+
+## Naver Whale Store
+
+- [Whale Store](https://store.whale.naver.com/)에 로그인한다.
+- My extensions 또는 개발자 관리 화면에서 LinKHU 항목으로 이동한다.
+- 새 패키지로 `linkhu-v{version}.zip`을 업로드한다.
+- 필수 정보, 권한, 심사용 설명을 확인한다.
+- 스토어 설명, 스크린샷, 카테고리 변경 필요 여부를 확인한다.
+- 제출 전 경고 메시지를 확인한다.
+- 심사를 제출한다.
+- 제출 후 심사 상태와 게시 상태를 기록한다.
+
+## 배포 후 확인
+
+- Chrome Web Store에서 표시되는 버전이 Release tag와 일치하는지 확인한다.
+- Firefox Add-ons에서 표시되는 버전이 Release tag와 일치하는지 확인한다.
+- Whale Store에서 표시되는 버전이 Release tag와 일치하는지 확인한다.
+- 각 스토어에서 새 설치 또는 업데이트가 가능한지 확인한다.
+- README의 Chrome, Firefox 사용자/버전 배지가 최신 상태로 갱신되는지 확인한다.
+- GitHub Release, 스토어 버전, `src/manifest.json` 버전이 모두 일치하는지 확인한다.
+
+## 자동화 후보
+
+- Chrome Web Store API 기반 패키지 업로드 및 게시
+- Firefox Add-ons API 기반 패키지 업로드 및 게시
+- Whale Store 자동화 가능성 조사
+- 스토어 배포 완료 상태를 기록하는 릴리스 체크 이슈 템플릿


### PR DESCRIPTION
## 📝 요약
> GitHub Release 이후 Chrome, Firefox, Whale 스토어에 수동 배포할 때 사용할 체크리스트를 문서화합니다.

## ⚙️ 작업 사항
- [x] docs/store-release-checklist.md 추가
- [x] 공통 배포 전 확인 항목 정리
- [x] Chrome Web Store, Firefox Add-ons, Naver Whale Store 수동 배포 절차 정리
- [x] 배포 후 버전/설치/배지 확인 항목 추가
- [x] README와 AGENTS.md에서 체크리스트 문서 링크 연결

## 📌 관련 이슈
- Close #29

## 🧪 테스트 결과
- npm run build
  - 데이터 검증: 113 sites 통과, HTTP URL 경고 18개 유지
  - 패키징: dist/linkhu-v2.3.0.zip 생성, 21 files 포함
- git diff --check
  - 통과
- docs/store-release-checklist.md 파일 존재 확인
  - 통과
- README/AGENTS.md 링크 경로 확인
  - docs/store-release-checklist.md

## 💡 리뷰 포인트
- 스토어별 수동 배포 절차의 상세 수준이 적절한지 확인 부탁드립니다.
- 자동화 후보를 이번 범위에서 분리한 판단이 적절한지 확인 부탁드립니다.
- Whale Store 절차는 공식 도움말 기준으로 작성했으므로 실제 개발자 화면 기준 보완이 필요한지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] src/data.js 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요?

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->