### PR TITLE
feat: Chrome Web Store 배포 자동화 추가

### DIFF
--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -1,0 +1,64 @@
+name: Publish Chrome Web Store
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Manifest version to publish, for example 2.3.0"
+        required: true
+        type: string
+      confirm_publish:
+        description: "Type publish-chrome to confirm Chrome Web Store submission"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish Chrome Web Store
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Verify release input
+        env:
+          CONFIRM_PUBLISH: ${{ inputs.confirm_publish }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "Chrome publish workflow must be run from main."
+            exit 1
+          fi
+
+          if [ "$CONFIRM_PUBLISH" != "publish-chrome" ]; then
+            echo "confirm_publish must be publish-chrome."
+            exit 1
+          fi
+
+          manifest_version="$(node -p "require('./src/manifest.json').version")"
+          if [ "$manifest_version" != "$INPUT_VERSION" ]; then
+            echo "Input version $INPUT_VERSION does not match manifest version $manifest_version."
+            exit 1
+          fi
+
+      - name: Build extension package
+        run: npm run build
+
+      - name: Publish to Chrome Web Store
+        env:
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_EXTENSION_ID: ihidkmjkpfphgljieecfcikljaopcldp
+          CHROME_PACKAGE_FILE: dist/linkhu-v${{ inputs.version }}.zip
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+        run: node scripts/publish-chrome.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ PR: feat: 공통 서비스 바로가기 추가
 - 릴리스 준비 PR이 머지된 뒤 같은 버전 태그를 push한다.
 - 버전 태그 push는 GitHub Release와 ZIP 첨부만 자동화한다.
 - Chrome, Firefox, Whale 스토어 배포는 별도 작업으로 다루며 `docs/store-release-checklist.md`를 따른다.
+- Chrome Web Store 자동 배포는 `docs/chrome-web-store-automation.md`를 따른다.
 
 ## 수동 검증 기준
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ git push origin "v$VERSION"
 릴리스 워크플로우는 `npm run build`로 패키징한 ZIP 파일을 첨부하고, `release-notes/v{version}.md` 내용을 릴리스 노트로 사용합니다.
 
 스토어 배포는 [스토어 배포 체크리스트](./docs/store-release-checklist.md)를 따릅니다.
+Chrome Web Store 자동 배포는 [Chrome Web Store Automation](./docs/chrome-web-store-automation.md)을 따릅니다.
 
 ## 🐛 버그 제보 및 기여
 사이트 추가 또는 서비스 개선 등 Issue와 Pull Request를 통한 버그 제보 및 새로운 기능 제안은 언제나 환영입니다!

--- a/docs/chrome-web-store-automation.md
+++ b/docs/chrome-web-store-automation.md
@@ -1,0 +1,42 @@
+# Chrome Web Store Automation
+
+Chrome Web Store 배포는 GitHub Actions의 `Publish Chrome Web Store` 워크플로우에서 수동으로 실행한다.
+
+## 동작 범위
+
+- `main` 브랜치에서만 실행한다.
+- 입력한 버전과 `src/manifest.json`의 `version`이 일치해야 한다.
+- `npm run build`로 `dist/linkhu-v{version}.zip`을 생성한다.
+- Chrome Web Store API로 ZIP 패키지를 업로드한다.
+- Chrome Web Store API로 publish 요청을 보내 심사에 제출한다.
+
+## 필요한 GitHub Actions secrets
+
+- `CHROME_CLIENT_ID`
+- `CHROME_CLIENT_SECRET`
+- `CHROME_REFRESH_TOKEN`
+- `CHROME_PUBLISHER_ID`
+
+Chrome Web Store extension ID는 워크플로우에 `ihidkmjkpfphgljieecfcikljaopcldp`로 고정되어 있다.
+
+## 실행 방법
+
+1. GitHub 저장소의 Actions 탭으로 이동한다.
+2. `Publish Chrome Web Store` 워크플로우를 선택한다.
+3. `Run workflow`를 누른다.
+4. Branch는 `main`을 선택한다.
+5. `version`에 배포할 manifest 버전을 입력한다.
+6. `confirm_publish`에 `publish-chrome`을 입력한다.
+7. 실행 후 Chrome Web Store Developer Dashboard에서 심사 상태를 확인한다.
+
+## 사전 확인
+
+- GitHub Release에 같은 버전의 ZIP asset이 생성되어 있는지 확인한다.
+- `release-notes/v{version}.md` 내용이 Chrome Web Store의 What's new에 반영되어 있는지 확인한다.
+- Store Listing, Privacy, Distribution 정보 변경이 필요한지 확인한다.
+- 권한 변경이 있는 경우 심사용 안내가 필요한지 확인한다.
+
+## 참고 문서
+
+- [Use the Chrome Web Store API](https://developer.chrome.com/docs/webstore/using_webstore_api)
+- [Chrome Web Store API reference](https://developer.chrome.com/docs/webstore/api/reference/rest)

--- a/scripts/publish-chrome.js
+++ b/scripts/publish-chrome.js
@@ -1,0 +1,165 @@
+const fs = require("fs");
+const path = require("path");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const MANIFEST_FILE = path.join(PROJECT_ROOT, "src", "manifest.json");
+
+function getRequiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} environment variable is required.`);
+  }
+  return value;
+}
+
+function readManifestVersion() {
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST_FILE, "utf8"));
+  if (!manifest.version) {
+    throw new Error("src/manifest.json must include a version.");
+  }
+  return manifest.version;
+}
+
+async function readResponseBody(response) {
+  const text = await response.text();
+  if (!text) return {};
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function requestJson(label, url, options) {
+  const response = await fetch(url, options);
+  const body = await readResponseBody(response);
+
+  if (!response.ok) {
+    const message = typeof body === "string" ? body : JSON.stringify(body);
+    throw new Error(`${label} failed (${response.status}): ${message}`);
+  }
+
+  return body;
+}
+
+function getPackageFile() {
+  const manifestVersion = readManifestVersion();
+  const packageFile =
+    process.env.CHROME_PACKAGE_FILE ||
+    path.join(PROJECT_ROOT, "dist", `linkhu-v${manifestVersion}.zip`);
+
+  if (!fs.existsSync(packageFile)) {
+    throw new Error(`Chrome package file does not exist: ${packageFile}`);
+  }
+
+  return packageFile;
+}
+
+async function getAccessToken(clientId, clientSecret, refreshToken) {
+  const tokenResponse = await requestJson(
+    "Chrome access token request",
+    "https://oauth2.googleapis.com/token",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+      }),
+    },
+  );
+
+  if (!tokenResponse.access_token) {
+    throw new Error("Chrome access token response did not include access_token.");
+  }
+
+  return tokenResponse.access_token;
+}
+
+async function uploadPackage(accessToken, publisherId, extensionId, packageFile) {
+  const packageData = fs.readFileSync(packageFile);
+  const url =
+    `https://chromewebstore.googleapis.com/upload/v2/publishers/` +
+    `${publisherId}/items/${extensionId}:upload`;
+
+  return requestJson("Chrome package upload", url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/zip",
+    },
+    body: packageData,
+  });
+}
+
+async function publishPackage(accessToken, publisherId, extensionId) {
+  const url =
+    `https://chromewebstore.googleapis.com/v2/publishers/` +
+    `${publisherId}/items/${extensionId}:publish`;
+
+  return requestJson("Chrome package publish", url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+}
+
+async function fetchStatus(accessToken, publisherId, extensionId) {
+  const url =
+    `https://chromewebstore.googleapis.com/v2/publishers/` +
+    `${publisherId}/items/${extensionId}:fetchStatus`;
+
+  return requestJson("Chrome item status fetch", url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+}
+
+async function main() {
+  try {
+    const packageFile = getPackageFile();
+    const publisherId = getRequiredEnv("CHROME_PUBLISHER_ID");
+    const extensionId = getRequiredEnv("CHROME_EXTENSION_ID");
+    const relativePackageFile = path.relative(PROJECT_ROOT, packageFile);
+
+    if (process.env.CHROME_DRY_RUN === "true") {
+      console.log(
+        `Chrome dry run: ${relativePackageFile} would be uploaded to ${extensionId}.`,
+      );
+      return;
+    }
+
+    const accessToken = await getAccessToken(
+      getRequiredEnv("CHROME_CLIENT_ID"),
+      getRequiredEnv("CHROME_CLIENT_SECRET"),
+      getRequiredEnv("CHROME_REFRESH_TOKEN"),
+    );
+
+    const uploadResponse = await uploadPackage(
+      accessToken,
+      publisherId,
+      extensionId,
+      packageFile,
+    );
+    console.log(`Chrome upload response: ${JSON.stringify(uploadResponse)}`);
+
+    const publishResponse = await publishPackage(accessToken, publisherId, extensionId);
+    console.log(`Chrome publish response: ${JSON.stringify(publishResponse)}`);
+
+    const statusResponse = await fetchStatus(accessToken, publisherId, extensionId);
+    console.log(`Chrome item status: ${JSON.stringify(statusResponse)}`);
+  } catch (error) {
+    console.error(`Chrome publish failed: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/scripts/publish-chrome.js
+++ b/scripts/publish-chrome.js
@@ -82,7 +82,7 @@ async function getAccessToken(clientId, clientSecret, refreshToken) {
 }
 
 async function uploadPackage(accessToken, publisherId, extensionId, packageFile) {
-  const packageData = fs.readFileSync(packageFile);
+  const packageData = await fs.promises.readFile(packageFile);
   const url =
     `https://chromewebstore.googleapis.com/upload/v2/publishers/` +
     `${publisherId}/items/${extensionId}:upload`;
@@ -149,13 +149,13 @@ async function main() {
       extensionId,
       packageFile,
     );
-    console.log(`Chrome upload response: ${JSON.stringify(uploadResponse)}`);
+    console.log(`Chrome upload response: ${JSON.stringify(uploadResponse, null, 2)}`);
 
     const publishResponse = await publishPackage(accessToken, publisherId, extensionId);
-    console.log(`Chrome publish response: ${JSON.stringify(publishResponse)}`);
+    console.log(`Chrome publish response: ${JSON.stringify(publishResponse, null, 2)}`);
 
     const statusResponse = await fetchStatus(accessToken, publisherId, extensionId);
-    console.log(`Chrome item status: ${JSON.stringify(statusResponse)}`);
+    console.log(`Chrome item status: ${JSON.stringify(statusResponse, null, 2)}`);
   } catch (error) {
     console.error(`Chrome publish failed: ${error.message}`);
     process.exitCode = 1;


### PR DESCRIPTION
## 📝 요약
> Actions에서 수동 실행하면 Chrome Web Store API로 LinKHU ZIP 패키지를 업로드하고 publish 심사 제출까지 진행하는 자동화를 추가합니다.

## ⚙️ 작업 사항
- [x] Chrome Web Store API 호출용 Node 스크립트 추가
- [x] workflow_dispatch 기반 Publish Chrome Web Store 워크플로우 추가
- [x] main 브랜치, 입력 버전, 확인 문구 검증 추가
- [x] npm run build 후 Chrome upload, publish, fetchStatus 호출
- [x] 필요한 GitHub Actions secrets와 실행 절차 문서화
- [x] README와 AGENTS.md에 Chrome 자동 배포 문서 링크 연결

## 📌 관련 이슈
- Close #31

## 🧪 테스트 결과
- npm run build
  - 데이터 검증: 113 sites 통과, HTTP URL 경고 18개 유지
  - 패키징: dist/linkhu-v2.3.0.zip 생성, 21 files 포함
- node --check scripts/publish-chrome.js
  - 통과
- ruby YAML 파싱 확인
  - .github/workflows/publish-chrome.yml 파싱 통과
- git diff --check
  - 통과
- Chrome publish dry run
  - dist/linkhu-v2.3.0.zip 업로드 대상 확인 통과

## 💡 리뷰 포인트
- Chrome Web Store publish를 workflow_dispatch 수동 실행으로 제한한 방식이 적절한지 확인 부탁드립니다.
- 필요한 secrets 이름이 충분히 명확한지 확인 부탁드립니다.
- publish 호출이 심사 제출까지 진행하는 동작이므로 확인 문구 publish-chrome 요구가 충분한지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] src/data.js 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요?

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->