### PR TITLE
docs: Chrome 자동 배포 운영 절차 보완

### DIFF
--- a/docs/chrome-web-store-automation.md
+++ b/docs/chrome-web-store-automation.md
@@ -29,6 +29,13 @@ Chrome Web Store extension ID는 워크플로우에 `ihidkmjkpfphgljieecfcikljao
 6. `confirm_publish`에 `publish-chrome`을 입력한다.
 7. 실행 후 Chrome Web Store Developer Dashboard에서 심사 상태를 확인한다.
 
+## 실행 후 확인
+
+- Actions 로그에서 upload, publish, fetchStatus 응답을 확인한다.
+- Chrome Web Store Developer Dashboard에서 새 버전이 심사 제출 상태인지 확인한다.
+- 심사 중 추가 조치가 필요한 경고나 메일이 있는지 확인한다.
+- 심사 통과 후 Chrome Web Store에 표시되는 버전이 `src/manifest.json`의 `version`과 일치하는지 확인한다.
+
 ## 사전 확인
 
 - GitHub Release에 같은 버전의 ZIP asset이 생성되어 있는지 확인한다.

--- a/docs/chrome-web-store-automation.md
+++ b/docs/chrome-web-store-automation.md
@@ -34,7 +34,6 @@ Chrome Web Store extension ID는 워크플로우에 `ihidkmjkpfphgljieecfcikljao
 - Actions 로그에서 upload, publish, fetchStatus 응답을 확인한다.
 - Chrome Web Store Developer Dashboard에서 새 버전이 심사 제출 상태인지 확인한다.
 - 심사 중 추가 조치가 필요한 경고나 메일이 있는지 확인한다.
-- 심사 통과 후 Chrome Web Store에 표시되는 버전이 `src/manifest.json`의 `version`과 일치하는지 확인한다.
 
 ## 사전 확인
 

--- a/docs/store-release-checklist.md
+++ b/docs/store-release-checklist.md
@@ -30,7 +30,7 @@ LinKHU 스토어 배포는 GitHub Release에 첨부된 ZIP 파일을 기준으�
 
 ## Chrome Web Store
 
-기본 배포 경로는 [Chrome Web Store Automation](./chrome-web-store-automation.md)의 `Publish Chrome Web Store` 워크플로우다. 아래 수동 절차는 자동 배포 실패 또는 긴급 fallback이 필요할 때 사용한다.
+기본 배포 경로는 [Chrome Web Store Automation](./chrome-web-store-automation.md)의 `Publish Chrome Web Store` 워크플로우다. 워크플로우 실행 후 대시보드에서 심사 제출 상태를 확인하며, 아래 수동 절차는 자동 배포 실패 또는 긴급 fallback이 필요할 때 사용한다.
 
 - [Chrome Developer Dashboard](https://chrome.google.com/webstore/devconsole)에 접속한다.
 - LinKHU 아이템을 선택한다.
@@ -68,7 +68,6 @@ LinKHU 스토어 배포는 GitHub Release에 첨부된 ZIP 파일을 기준으�
 ## 배포 후 확인
 
 - Chrome Web Store에서 표시되는 버전이 Release tag와 일치하는지 확인한다.
-- Chrome Web Store 자동 배포 실행 후 심사 제출 상태가 표시되는지 확인한다.
 - Firefox Add-ons에서 표시되는 버전이 Release tag와 일치하는지 확인한다.
 - Whale Store에서 표시되는 버전이 Release tag와 일치하는지 확인한다.
 - 각 스토어에서 새 설치 또는 업데이트가 가능한지 확인한다.

--- a/docs/store-release-checklist.md
+++ b/docs/store-release-checklist.md
@@ -30,6 +30,8 @@ LinKHU 스토어 배포는 GitHub Release에 첨부된 ZIP 파일을 기준으�
 
 ## Chrome Web Store
 
+기본 배포 경로는 [Chrome Web Store Automation](./chrome-web-store-automation.md)의 `Publish Chrome Web Store` 워크플로우다. 아래 수동 절차는 자동 배포 실패 또는 긴급 fallback이 필요할 때 사용한다.
+
 - [Chrome Developer Dashboard](https://chrome.google.com/webstore/devconsole)에 접속한다.
 - LinKHU 아이템을 선택한다.
 - 새 패키지로 `linkhu-v{version}.zip`을 업로드한다.
@@ -66,6 +68,7 @@ LinKHU 스토어 배포는 GitHub Release에 첨부된 ZIP 파일을 기준으�
 ## 배포 후 확인
 
 - Chrome Web Store에서 표시되는 버전이 Release tag와 일치하는지 확인한다.
+- Chrome Web Store 자동 배포 실행 후 심사 제출 상태가 표시되는지 확인한다.
 - Firefox Add-ons에서 표시되는 버전이 Release tag와 일치하는지 확인한다.
 - Whale Store에서 표시되는 버전이 Release tag와 일치하는지 확인한다.
 - 각 스토어에서 새 설치 또는 업데이트가 가능한지 확인한다.


### PR DESCRIPTION
## 📝 요약
> Chrome Web Store 자동 배포가 실제 심사 제출까지 동작한 결과를 반영해 운영 문서를 보완합니다.

## ⚙️ 작업 사항
- [x] 스토어 배포 체크리스트에서 Chrome 기본 배포 경로를 자동 배포 워크플로우로 안내
- [x] Chrome 수동 업로드 절차를 fallback 절차로 명시
- [x] Chrome 자동 배포 실행 후 확인 항목 추가

## 📌 관련 이슈
- Close #33

## 🧪 테스트 결과
- npm run build
  - 데이터 검증: 113 sites 통과, HTTP URL 경고 18개 유지
  - 패키징: dist/linkhu-v2.3.0.zip 생성, 21 files 포함
- git diff --check
  - 통과
- 문서 링크 파일 존재 확인
  - docs/chrome-web-store-automation.md
  - docs/store-release-checklist.md

## 💡 리뷰 포인트
- Chrome 자동 배포를 기본 경로로 설명하고 수동 절차를 fallback으로 남긴 구성이 적절한지 확인 부탁드립니다.
- 심사 제출 후 확인 항목이 충분한지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] src/data.js 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요?

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->