### PR TITLE
feat: 단축키 설정 상태 안내 추가

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -38,12 +38,12 @@ body {
 h1 {
   color: #9d2235;
   text-align: center;
-  margin-bottom: 5px;
+  margin: 0 0 4px;
 }
 .info {
   text-align: center;
   color: #666;
-  margin-bottom: 30px;
+  margin: 0 0 24px;
   font-size: 14px;
 }
 

--- a/src/options.css
+++ b/src/options.css
@@ -43,7 +43,7 @@ h1 {
 .info {
   text-align: center;
   color: #666;
-  margin-bottom: 18px;
+  margin-bottom: 30px;
   font-size: 14px;
 }
 

--- a/src/options.css
+++ b/src/options.css
@@ -43,8 +43,53 @@ h1 {
 .info {
   text-align: center;
   color: #666;
-  margin-bottom: 30px;
+  margin-bottom: 18px;
   font-size: 14px;
+}
+
+.shortcut-guide {
+  margin-bottom: 18px;
+  padding: 14px 16px;
+  border: 1px solid #f1c7cf;
+  border-radius: 8px;
+  background: #fff7f8;
+  color: #333;
+  font-size: 13px;
+}
+
+.shortcut-guide strong {
+  display: block;
+  margin-bottom: 6px;
+  color: #9d2235;
+}
+
+.shortcut-guide p {
+  margin: 0 0 8px;
+  color: #555;
+}
+
+.shortcut-guide ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.shortcut-guide li + li {
+  margin-top: 4px;
+}
+
+.shortcut-link {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #9d2235;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.shortcut-link:hover {
+  text-decoration: underline;
 }
 
 /* 3. 2단 레이아웃 (왼쪽 후보 구역 / 오른쪽 내 바로가기 구역) */

--- a/src/options.html
+++ b/src/options.html
@@ -12,6 +12,35 @@
         원하는 사이트를 드래그하여 오른쪽 '내 바로가기'로 옮겨주세요.
       </p>
 
+      <div id="shortcut-guide" class="shortcut-guide" hidden>
+        <strong>단축키가 설정되어 있지 않습니다.</strong>
+        <p>
+          브라우저 확장 프로그램 단축키 설정 화면에서 LinKHU 단축키를 직접
+          지정해주세요.
+        </p>
+        <ul>
+          <li>
+            Chrome:
+            <button type="button" class="shortcut-link" data-shortcut-url="chrome://extensions/shortcuts">
+              chrome://extensions/shortcuts
+            </button>
+          </li>
+          <li>
+            Whale:
+            <button type="button" class="shortcut-link" data-shortcut-url="whale://extensions/shortcuts">
+              whale://extensions/shortcuts
+            </button>
+          </li>
+          <li>
+            Firefox:
+            <button type="button" class="shortcut-link" data-shortcut-url="about:addons">
+              about:addons
+            </button>
+            → 톱니바퀴 메뉴 → 확장 기능 단축키 관리
+          </li>
+        </ul>
+      </div>
+
       <div class="board">
         <div class="column">
           <h2>사용 가능한 사이트</h2>

--- a/src/options.js
+++ b/src/options.js
@@ -22,9 +22,13 @@ document.addEventListener("DOMContentLoaded", () => {
       chrome.tabs.create({ url }, () => {
         if (!chrome.runtime.lastError) return;
 
-        navigator.clipboard.writeText(url).then(() => {
-          alert(`${url} 주소를 복사했습니다. 주소창에 붙여넣어 이동해주세요.`);
-        });
+        navigator.clipboard.writeText(url)
+          .then(() => {
+            alert(`${url} 주소를 복사했습니다. 주소창에 붙여넣어 이동해주세요.`);
+          })
+          .catch(() => {
+            alert(`${url} 주소를 직접 복사하여 주소창에 붙여넣어 이동해주세요.`);
+          });
       });
     });
   });

--- a/src/options.js
+++ b/src/options.js
@@ -3,6 +3,31 @@ document.addEventListener("DOMContentLoaded", () => {
   const activeList = document.getElementById("active-list");
   const saveBtn = document.getElementById("save-btn");
   const leftColumn = document.querySelector(".column:first-child"); // 왼쪽 후보 영역
+  const shortcutGuide = document.getElementById("shortcut-guide");
+
+  if (shortcutGuide && chrome.commands?.getAll) {
+    chrome.commands.getAll((commands) => {
+      const actionCommand = commands.find(
+        (command) => command.name === "_execute_action",
+      );
+      shortcutGuide.hidden = Boolean(actionCommand?.shortcut);
+    });
+  }
+
+  document.querySelectorAll(".shortcut-link").forEach((button) => {
+    button.addEventListener("click", () => {
+      const url = button.dataset.shortcutUrl;
+      if (!url) return;
+
+      chrome.tabs.create({ url }, () => {
+        if (!chrome.runtime.lastError) return;
+
+        navigator.clipboard.writeText(url).then(() => {
+          alert(`${url} 주소를 복사했습니다. 주소창에 붙여넣어 이동해주세요.`);
+        });
+      });
+    });
+  });
 
   // 왼쪽 카테고리별 구역(Drop Zone) 매핑
   const categoryZones = {


### PR DESCRIPTION
## 📝 요약
> 이번 PR에서 작업한 핵심 내용을 간단히 적어주세요.

설정 화면에서 LinKHU 팝업 열기 단축키가 비어 있는지 확인하고, 단축키가 설정되어 있지 않으면 브라우저별 단축키 설정 경로를 안내합니다. 안내 항목은 클릭 시 해당 설정 페이지 열기를 시도하고, 브라우저가 내부 주소 이동을 막으면 주소를 클립보드에 복사합니다.

## ⚙️ 작업 사항
- [x] 설정 화면 단축키 안내 박스 추가
- [x] `chrome.commands.getAll()`로 `_execute_action` shortcut 상태 확인
- [x] 단축키가 등록되어 있으면 안내 숨김 처리
- [x] Chrome, Whale, Firefox 단축키 설정 경로 안내
- [x] 내부 주소 이동 실패 시 클립보드 복사 fallback 추가

## 📌 관련 이슈
- Close #55

## 🧪 테스트 결과
> 작업한 내용이 의도대로 동작하는지 확인한 결과(스크린샷, 로그 등)를 첨부해주세요.

- `node --check src/options.js` 통과
- `git diff --check` 통과
- `npm run build` 통과
  - `Validated 113 sites.`
  - 기존 HTTP URL 경고 18건 유지
  - `Packaged 124 files into dist/linkhu-v2.3.1.zip.`
- 수동 확인: 단축키 설정 안내의 경로 클릭 동작 확인

## 💡 리뷰 포인트
- 단축키가 비어 있을 때만 안내하는 흐름이 충분한지 확인 부탁드립니다.
- 내부 브라우저 설정 주소 이동 실패 시 클립보드 복사 fallback 문구가 적절한지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요?
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요?

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->