### PR TITLE
feat: 설정 페이지 서비스 검색 기능 추가

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -126,6 +126,52 @@ h1 {
   flex-shrink: 0;
 }
 
+.option-search {
+  position: relative;
+  flex-shrink: 0;
+  margin-bottom: 12px;
+}
+
+.option-search::before {
+  content: "🔍";
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 13px;
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.option-search input {
+  width: 100%;
+  height: 36px;
+  padding: 0 12px 0 32px;
+  box-sizing: border-box;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background: #fff;
+  color: #333;
+  font-size: 13px;
+  outline: none;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.option-search input:focus {
+  border-color: #9d2235;
+  box-shadow: 0 0 0 3px rgba(157, 34, 53, 0.12);
+}
+
+.search-empty-message {
+  flex-shrink: 0;
+  margin: 0 0 12px;
+  color: #777;
+  font-size: 13px;
+  text-align: center;
+}
+
 /* 4. 스크롤 영역 (덜컹거림 방지의 핵심) */
 .scroll-area {
   flex-grow: 1; /* h2 제목이 차지하고 남은 아래 공간을 꽉 채움 */

--- a/src/options.html
+++ b/src/options.html
@@ -44,6 +44,18 @@
       <div class="board">
         <div class="column">
           <h2>사용 가능한 사이트</h2>
+          <div class="option-search">
+            <input
+              id="site-search"
+              type="search"
+              placeholder="서비스 검색"
+              autocomplete="off"
+              aria-label="서비스 검색"
+            />
+          </div>
+          <p id="search-empty-message" class="search-empty-message" hidden>
+            검색 결과 없음
+          </p>
           <div class="scroll-area">
             <div class="category-group">
               <div class="category-title">📌 공통 서비스</div>

--- a/src/options.js
+++ b/src/options.js
@@ -52,6 +52,7 @@ document.addEventListener("DOMContentLoaded", () => {
       normalize(`${site.name}${site.id}${site.category}`),
     ]),
   );
+  const listItemById = new Map();
 
   function matchesSearch(site, query) {
     return siteSearchTextById.get(site.id).includes(query);
@@ -70,19 +71,18 @@ document.addEventListener("DOMContentLoaded", () => {
     const activeIds = getActiveIds();
     let visibleCount = 0;
 
-    Object.entries(categoryZones).forEach(([, zone]) => {
+    const filteredSites = MASTER_SITE_LIST.filter((site) => {
+      if (activeIds.has(site.id)) return false;
+      return !query || matchesSearch(site, query);
+    }).sort((a, b) => a.name.localeCompare(b.name, "ko-KR"));
+
+    Object.entries(categoryZones).forEach(([category, zone]) => {
       const group = zone.closest(".category-group");
-      zone.innerHTML = "";
+      const matchingSites = filteredSites.filter(
+        (site) => site.category === category,
+      );
 
-      const matchingSites = MASTER_SITE_LIST.filter((site) => {
-        if (activeIds.has(site.id)) return false;
-        if (site.category !== zone.dataset.category) return false;
-        return !query || matchesSearch(site, query);
-      }).sort((a, b) => a.name.localeCompare(b.name, "ko-KR"));
-
-      matchingSites.forEach((site) => {
-        zone.appendChild(createListItem(site));
-      });
+      zone.replaceChildren(...matchingSites.map((site) => createListItem(site)));
 
       visibleCount += matchingSites.length;
       if (group) group.hidden = Boolean(query && matchingSites.length === 0);
@@ -131,6 +131,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // 3. [함수] 사이트 리스트 아이템 HTML 생성
   function createListItem(site) {
+    if (listItemById.has(site.id)) {
+      return listItemById.get(site.id);
+    }
+
     const el = document.createElement("div");
     el.className = "list-item";
     el.draggable = true; // 드래그 가능하게 설정
@@ -154,6 +158,7 @@ document.addEventListener("DOMContentLoaded", () => {
     el.append(dragHandle, icon, siteName);
 
     addDragEvents(el); // 아이템에 드래그 기능 심어주기
+    listItemById.set(site.id, el);
     return el;
   }
 

--- a/src/options.js
+++ b/src/options.js
@@ -46,26 +46,46 @@ document.addEventListener("DOMContentLoaded", () => {
     return String(value || "").toLowerCase().replace(/\s+/g, "");
   }
 
-  function matchesSearch(item, query) {
-    return item.dataset.searchText.includes(query);
+  const siteSearchTextById = new Map(
+    MASTER_SITE_LIST.map((site) => [
+      site.id,
+      normalize(`${site.name}${site.id}${site.category}`),
+    ]),
+  );
+
+  function matchesSearch(site, query) {
+    return siteSearchTextById.get(site.id).includes(query);
+  }
+
+  function getActiveIds() {
+    return new Set(
+      Array.from(activeList.querySelectorAll(".list-item")).map(
+        (item) => item.dataset.id,
+      ),
+    );
   }
 
   function updateSearchResults() {
     const query = normalize(searchInput?.value);
+    const activeIds = getActiveIds();
     let visibleCount = 0;
 
     Object.entries(categoryZones).forEach(([, zone]) => {
       const group = zone.closest(".category-group");
-      let groupVisibleCount = 0;
+      zone.innerHTML = "";
 
-      zone.querySelectorAll(".list-item").forEach((item) => {
-        const isVisible = !query || matchesSearch(item, query);
-        item.hidden = !isVisible;
-        if (isVisible) groupVisibleCount += 1;
+      const matchingSites = MASTER_SITE_LIST.filter((site) => {
+        if (activeIds.has(site.id)) return false;
+        if (site.category !== zone.dataset.category) return false;
+        return !query || matchesSearch(site, query);
+      }).sort((a, b) => a.name.localeCompare(b.name, "ko-KR"));
+
+      matchingSites.forEach((site) => {
+        zone.appendChild(createListItem(site));
       });
 
-      visibleCount += groupVisibleCount;
-      if (group) group.hidden = Boolean(query && groupVisibleCount === 0);
+      visibleCount += matchingSites.length;
+      if (group) group.hidden = Boolean(query && matchingSites.length === 0);
     });
 
     if (searchEmptyMessage) {
@@ -92,21 +112,11 @@ document.addEventListener("DOMContentLoaded", () => {
       result.userOrder ||
       MASTER_SITE_LIST.filter((s) => s.category === "공통").map((s) => s.id);
 
-    MASTER_SITE_LIST.forEach((site) => {
-      const el = createListItem(site);
-
-      if (activeOrder.includes(site.id)) {
+    MASTER_SITE_LIST.filter((site) => activeOrder.includes(site.id)).forEach(
+      (site) => {
+        const el = createListItem(site);
         activeList.appendChild(el); // 오른쪽(내 바로가기)으로 배치
-      } else {
-        if (categoryZones[site.category]) {
-          categoryZones[site.category].appendChild(el); // 원래 카테고리 칸으로 배치
-        }
-      }
-    });
-
-    // 왼쪽 구역들은 배치가 끝나면 바로 가나다 정렬 실행
-    Object.values(categoryZones).forEach((zone) =>
-      sortZoneAlphabetically(zone),
+      },
     );
 
     // 오른쪽은 사용자가 저장했던 '그 순서' 그대로 다시 재배치
@@ -115,6 +125,7 @@ document.addEventListener("DOMContentLoaded", () => {
       if (item) activeList.appendChild(item);
     });
 
+    // 왼쪽 후보 목록은 전체 서비스에서 활성화된 항목을 제외하고 렌더링
     updateSearchResults();
   });
 
@@ -126,7 +137,6 @@ document.addEventListener("DOMContentLoaded", () => {
     el.dataset.id = site.id;
     el.dataset.name = site.name;
     el.dataset.category = site.category;
-    el.dataset.searchText = normalize(`${site.name}${site.id}${site.category}`);
 
     const dragHandle = document.createElement("div");
     dragHandle.className = "drag-handle";

--- a/src/options.js
+++ b/src/options.js
@@ -47,8 +47,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function matchesSearch(item, query) {
-    return [item.dataset.name, item.dataset.id, item.dataset.category]
-      .some((value) => normalize(value).includes(query));
+    return item.dataset.searchText.includes(query);
   }
 
   function updateSearchResults() {
@@ -127,6 +126,7 @@ document.addEventListener("DOMContentLoaded", () => {
     el.dataset.id = site.id;
     el.dataset.name = site.name;
     el.dataset.category = site.category;
+    el.dataset.searchText = normalize(`${site.name}${site.id}${site.category}`);
 
     const dragHandle = document.createElement("div");
     dragHandle.className = "drag-handle";
@@ -155,6 +155,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (
       e.target.tagName === "INPUT" ||
       e.target.tagName === "TEXTAREA" ||
+      e.target.tagName === "SELECT" ||
       e.target.isContentEditable ||
       e.ctrlKey ||
       e.altKey ||

--- a/src/options.js
+++ b/src/options.js
@@ -4,6 +4,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const saveBtn = document.getElementById("save-btn");
   const leftColumn = document.querySelector(".column:first-child"); // 왼쪽 후보 영역
   const shortcutGuide = document.getElementById("shortcut-guide");
+  const searchInput = document.getElementById("site-search");
+  const searchEmptyMessage = document.getElementById("search-empty-message");
 
   if (shortcutGuide && chrome.commands?.getAll) {
     chrome.commands.getAll((commands) => {
@@ -39,6 +41,38 @@ document.addEventListener("DOMContentLoaded", () => {
     단과대: document.getElementById("zone-단과대"),
     학과: document.getElementById("zone-학과"),
   };
+
+  function normalize(value) {
+    return String(value || "").toLowerCase().replace(/\s+/g, "");
+  }
+
+  function matchesSearch(item, query) {
+    return [item.dataset.name, item.dataset.id, item.dataset.category]
+      .some((value) => normalize(value).includes(query));
+  }
+
+  function updateSearchResults() {
+    const query = normalize(searchInput?.value);
+    let visibleCount = 0;
+
+    Object.entries(categoryZones).forEach(([, zone]) => {
+      const group = zone.closest(".category-group");
+      let groupVisibleCount = 0;
+
+      zone.querySelectorAll(".list-item").forEach((item) => {
+        const isVisible = !query || matchesSearch(item, query);
+        item.hidden = !isVisible;
+        if (isVisible) groupVisibleCount += 1;
+      });
+
+      visibleCount += groupVisibleCount;
+      if (group) group.hidden = Boolean(query && groupVisibleCount === 0);
+    });
+
+    if (searchEmptyMessage) {
+      searchEmptyMessage.hidden = !query || visibleCount > 0;
+    }
+  }
 
   // 🔠 [함수] 리스트를 가나다순으로 자동 정렬
   function sortZoneAlphabetically(zone) {
@@ -81,6 +115,8 @@ document.addEventListener("DOMContentLoaded", () => {
       const item = activeList.querySelector(`[data-id="${id}"]`);
       if (item) activeList.appendChild(item);
     });
+
+    updateSearchResults();
   });
 
   // 3. [함수] 사이트 리스트 아이템 HTML 생성
@@ -89,6 +125,7 @@ document.addEventListener("DOMContentLoaded", () => {
     el.className = "list-item";
     el.draggable = true; // 드래그 가능하게 설정
     el.dataset.id = site.id;
+    el.dataset.name = site.name;
     el.dataset.category = site.category;
 
     const dragHandle = document.createElement("div");
@@ -109,6 +146,29 @@ document.addEventListener("DOMContentLoaded", () => {
     addDragEvents(el); // 아이템에 드래그 기능 심어주기
     return el;
   }
+
+  if (searchInput) {
+    searchInput.addEventListener("input", updateSearchResults);
+  }
+
+  document.addEventListener("keydown", (e) => {
+    if (
+      e.target.tagName === "INPUT" ||
+      e.target.tagName === "TEXTAREA" ||
+      e.target.isContentEditable ||
+      e.ctrlKey ||
+      e.altKey ||
+      e.metaKey ||
+      e.repeat
+    ) {
+      return;
+    }
+
+    if (e.key === "/") {
+      e.preventDefault();
+      searchInput?.focus();
+    }
+  });
 
   // 4. 저장 버튼: 현재 오른쪽 리스트의 순서를 따서 저장
   saveBtn.addEventListener("click", () => {
@@ -139,6 +199,7 @@ document.addEventListener("DOMContentLoaded", () => {
       scrollDirection = 0;
       currentScrollArea = null;
       scrollAreaRect = null;
+      updateSearchResults();
     });
   }
 


### PR DESCRIPTION
## 📝 요약
> 이번 PR에서 작업한 핵심 내용을 간단히 적어주세요.

설정 페이지의 왼쪽 사용 가능한 사이트 영역에 서비스 검색 기능을 추가했습니다. 검색어가 없으면 기존 목록을 유지하고, 검색 중에는 왼쪽 후보 목록만 필터링하며 오른쪽 내 바로가기 목록은 그대로 유지합니다.

## ⚙️ 작업 사항
- [x] 설정 페이지 사용 가능한 사이트 영역에 검색 입력 추가
- [x] 서비스 이름, id, 카테고리 기반 검색 처리
- [x] 검색 결과 없음 상태 추가
- [x] `/` 키로 설정 페이지 검색창 포커스 처리
- [x] 드래그 앤 드롭 후 검색 필터 상태 재계산

## 📌 관련 이슈
- Close #57

## 🧪 테스트 결과
> 작업한 내용이 의도대로 동작하는지 확인한 결과(스크린샷, 로그 등)를 첨부해주세요.

- `node --check src/options.js` 통과
- `git diff --check` 통과
- `npm run build` 통과
  - `Validated 113 sites.`
  - 기존 HTTP URL 경고 18건 유지
  - `Packaged 124 files into dist/linkhu-v2.3.1.zip.`

## 💡 리뷰 포인트
- 검색 대상을 왼쪽 후보 목록으로 한정한 흐름이 설정 페이지 사용성에 적절한지 확인 부탁드립니다.
- 검색 중 카테고리 그룹을 숨기는 동작이 자연스러운지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요?
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요?

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->