### PR TITLE
refactor: 팝업·설정 공통 검색/설정 유틸 추출

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -92,6 +92,7 @@
     </div>
 
     <script src="data.js"></script>
+    <script src="shared.js"></script>
     <script src="options.js"></script>
   </body>
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -48,14 +48,10 @@ document.addEventListener("DOMContentLoaded", () => {
     학과: document.getElementById("zone-학과"),
   };
 
-  function normalize(value) {
-    return String(value || "").toLowerCase().replace(/\s+/g, "");
-  }
-
   const siteSearchTextById = new Map(
     MASTER_SITE_LIST.map((site) => [
       site.id,
-      normalize(`${site.name}${site.id}${site.category}`),
+      LinKHUShared.normalize(`${site.name}${site.id}${site.category}`),
     ]),
   );
   const listItemById = new Map();
@@ -73,7 +69,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function updateSearchResults() {
-    const query = normalize(searchInput?.value);
+    const query = LinKHUShared.normalize(searchInput?.value);
     const activeIds = getActiveIds();
     let visibleCount = 0;
 
@@ -111,8 +107,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   chrome.storage.local.get(["userOrder"], (result) => {
     const activeOrder =
-      result.userOrder ||
-      MASTER_SITE_LIST.filter((s) => s.category === "공통").map((s) => s.id);
+      result.userOrder || LinKHUShared.getDefaultOrder(MASTER_SITE_LIST);
 
     MASTER_SITE_LIST.filter((site) => activeOrder.includes(site.id)).forEach(
       (site) => {

--- a/src/popup.html
+++ b/src/popup.html
@@ -79,6 +79,7 @@
     </div>
 
     <script src="data.js"></script>
+    <script src="shared.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -3,15 +3,6 @@ const App = {
   currentItems: [],
   renderToken: 0,
 
-  normalize(value) {
-    return String(value || "").toLowerCase().replace(/\s+/g, "");
-  },
-
-  matchesSearch(item, query) {
-    return [item.name, item.id, item.category]
-      .some((value) => this.normalize(value).includes(query));
-  },
-
   getUniqueSites(sites) {
     const seenIds = new Set();
     return sites.filter((site) => {
@@ -80,18 +71,18 @@ const App = {
     chrome.storage.local.get(["userOrder"], (result) => {
       if (renderToken !== this.renderToken) return;
 
-      const order =
-        result.userOrder ||
-        MASTER_SITE_LIST.filter((s) => s.category === "공통").map((s) => s.id);
+      const order = result.userOrder || LinKHUShared.getDefaultOrder(MASTER_SITE_LIST);
 
       const configuredSites = order
         .map((id) => MASTER_SITE_LIST.find((s) => s.id === id))
         .filter(Boolean);
 
-      const query = this.normalize(this.searchQuery);
+      const query = LinKHUShared.normalize(this.searchQuery);
       const sourceSites = query ? MASTER_SITE_LIST : configuredSites;
       const displaySites = this.getUniqueSites(
-        sourceSites.filter((site) => !query || this.matchesSearch(site, query)),
+        sourceSites.filter(
+          (site) => !query || LinKHUShared.matchesSearch(site, query),
+        ),
       );
       this.currentItems = displaySites;
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,0 +1,26 @@
+// 팝업(popup.js)과 설정(options.js)이 함께 쓰는 검색/설정 유틸.
+// 랜딩 페이지(docs/landing.js)는 파일을 공유할 수 없으므로,
+// 검색 정규화 규칙을 바꿀 때는 docs/landing.js와 동작을 맞춘다.
+const LinKHUShared = {
+  normalize(value) {
+    return String(value || "")
+      .toLocaleLowerCase("ko-KR")
+      .replace(/\s+/g, "");
+  },
+
+  matchesSearch(site, normalizedQuery) {
+    return [site.name, site.id, site.category].some((value) =>
+      this.normalize(value).includes(normalizedQuery),
+    );
+  },
+
+  getDefaultOrder(siteList) {
+    return siteList
+      .filter((site) => site.category === "공통")
+      .map((site) => site.id);
+  },
+};
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = LinKHUShared;
+}

--- a/tests/browser-behavior.test.js
+++ b/tests/browser-behavior.test.js
@@ -31,8 +31,13 @@ class FakeElement {
   }
 }
 
-function loadScript(relativePath, additions, overrides = {}) {
-  const source = fs.readFileSync(path.join(PROJECT_ROOT, relativePath), "utf8");
+function loadScript(relativePaths, additions, overrides = {}) {
+  const paths = Array.isArray(relativePaths) ? relativePaths : [relativePaths];
+  const source = paths
+    .map((relativePath) =>
+      fs.readFileSync(path.join(PROJECT_ROOT, relativePath), "utf8"),
+    )
+    .join("\n");
   const context = {
     console,
     setInterval,
@@ -50,38 +55,17 @@ function loadScript(relativePath, additions, overrides = {}) {
 
   vm.createContext(context);
   vm.runInContext(`${source}\n${additions}`, context, {
-    filename: relativePath,
+    filename: paths[paths.length - 1],
   });
   return context;
 }
 
-test("popup search normalizes spaces and letter case", () => {
+test("popup removes duplicate site ids while preserving order", () => {
   const context = loadScript(
-    "src/popup.js",
-    "this.AppForTest = App; this.VersionManagerForTest = VersionManager;",
+    ["src/shared.js", "src/popup.js"],
+    "this.AppForTest = App;",
     { chrome: {} },
   );
-
-  assert.equal(
-    context.AppForTest.matchesSearch(
-      { id: "e-campus", name: "e-Campus", category: "공통" },
-      "e-campus",
-    ),
-    true,
-  );
-  assert.equal(
-    context.AppForTest.matchesSearch(
-      { id: "software", name: "소프트웨어 융합대학", category: "단과대" },
-      context.AppForTest.normalize("소프트웨어융합 대학"),
-    ),
-    true,
-  );
-});
-
-test("popup removes duplicate site ids while preserving order", () => {
-  const context = loadScript("src/popup.js", "this.AppForTest = App;", {
-    chrome: {},
-  });
   const sites = [
     { id: "first" },
     { id: "second" },
@@ -97,7 +81,10 @@ test("popup removes duplicate site ids while preserving order", () => {
 test("popup opens normal, modifier, and middle clicks with expected focus", () => {
   const createdTabs = [];
   let closeCount = 0;
-  const context = loadScript("src/popup.js", "this.AppForTest = App;", {
+  const context = loadScript(
+    ["src/shared.js", "src/popup.js"],
+    "this.AppForTest = App;",
+    {
     chrome: {
       tabs: {
         create(options) {

--- a/tests/shared.test.js
+++ b/tests/shared.test.js
@@ -1,0 +1,32 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const LinKHUShared = require("../src/shared");
+
+test("shared normalize removes spaces and letter case", () => {
+  assert.equal(LinKHUShared.normalize("  e Campus "), "ecampus");
+  assert.equal(LinKHUShared.normalize("소프트웨어 융합대학"), "소프트웨어융합대학");
+  assert.equal(LinKHUShared.normalize(null), "");
+});
+
+test("shared matchesSearch matches name, id, and category", () => {
+  const site = { id: "software", name: "소프트웨어 융합대학", category: "단과대" };
+
+  assert.equal(
+    LinKHUShared.matchesSearch(site, LinKHUShared.normalize("소프트웨어융합 대학")),
+    true,
+  );
+  assert.equal(LinKHUShared.matchesSearch(site, "software"), true);
+  assert.equal(LinKHUShared.matchesSearch(site, "단과대"), true);
+  assert.equal(LinKHUShared.matchesSearch(site, "없는검색어"), false);
+});
+
+test("shared getDefaultOrder keeps 공통 sites in list order", () => {
+  const sites = [
+    { id: "a", category: "공통" },
+    { id: "b", category: "학과" },
+    { id: "c", category: "공통" },
+  ];
+
+  assert.deepEqual(LinKHUShared.getDefaultOrder(sites), ["a", "c"]);
+});


### PR DESCRIPTION
## 📝 요약
> `normalize`, 검색 매칭, 기본 순서(userOrder fallback) 로직이 popup.js / options.js에 서로 다르게 복제되어 있던 것을 `src/shared.js` 하나로 통합했습니다.

## ⚙️ 작업 사항
- [x] `src/shared.js` 신설 (`normalize`, `matchesSearch`, `getDefaultOrder`)
- [x] popup.js / options.js 중복 구현 제거 및 공유 유틸 사용
- [x] popup.html / options.html에 shared.js 로드 추가
- [x] 테스트 하네스 다중 파일 로드 지원 + `tests/shared.test.js` 추가

## 📌 관련 이슈
- Close #73

## 🧪 테스트 결과
- `npm run build` 통과 (tests 16 pass / 0 fail, 데이터 검증 통과, 127개 파일 패키징)

## 💡 리뷰 포인트
- `normalize`가 기존 `toLowerCase()`에서 `toLocaleLowerCase("ko-KR")`로 통일되었습니다(랜딩 페이지와 동일 규칙). 한글/영문 입력에서는 동작 차이가 없습니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [ ] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [ ] 문서(Wiki, API Docs 등)를 업데이트했나요? (해당 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)