### PR TITLE
refactor: 설정 페이지 스크립트 구조 정리

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -10,37 +10,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const activeList = document.getElementById("active-list");
   const saveBtn = document.getElementById("save-btn");
   const leftColumn = document.querySelector(".column:first-child");
-  const shortcutGuide = document.getElementById("shortcut-guide");
   const searchInput = document.getElementById("site-search");
   const searchEmptyMessage = document.getElementById("search-empty-message");
-
-  if (shortcutGuide && chrome.commands?.getAll) {
-    chrome.commands.getAll((commands) => {
-      const actionCommand = commands.find(
-        (command) => command.name === "_execute_action",
-      );
-      shortcutGuide.hidden = Boolean(actionCommand?.shortcut);
-    });
-  }
-
-  document.querySelectorAll(".shortcut-link").forEach((button) => {
-    button.addEventListener("click", () => {
-      const url = button.dataset.shortcutUrl;
-      if (!url) return;
-
-      chrome.tabs.create({ url }, () => {
-        if (!chrome.runtime.lastError) return;
-
-        navigator.clipboard.writeText(url)
-          .then(() => {
-            alert(`${url} 주소를 복사했습니다. 주소창에 붙여넣어 이동해주세요.`);
-          })
-          .catch(() => {
-            alert(`${url} 주소를 직접 복사하여 주소창에 붙여넣어 이동해주세요.`);
-          });
-      });
-    });
-  });
 
   const categoryZones = {
     공통: document.getElementById("zone-공통"),
@@ -48,81 +19,42 @@ document.addEventListener("DOMContentLoaded", () => {
     학과: document.getElementById("zone-학과"),
   };
 
-  const siteSearchTextById = new Map(
-    MASTER_SITE_LIST.map((site) => [
-      site.id,
-      LinKHUShared.normalize(`${site.name}${site.id}${site.category}`),
-    ]),
-  );
-  const listItemById = new Map();
-
-  function matchesSearch(site, query) {
-    return siteSearchTextById.get(site.id).includes(query);
+  function compareSiteNames(nameA, nameB) {
+    return nameA.localeCompare(nameB, "ko-KR");
   }
 
-  function getActiveIds() {
-    return new Set(
-      Array.from(activeList.querySelectorAll(".list-item")).map(
-        (item) => item.dataset.id,
-      ),
-    );
-  }
-
-  function updateSearchResults() {
-    const query = LinKHUShared.normalize(searchInput?.value);
-    const activeIds = getActiveIds();
-    let visibleCount = 0;
-
-    const filteredSites = MASTER_SITE_LIST.filter((site) => {
-      if (activeIds.has(site.id)) return false;
-      return !query || matchesSearch(site, query);
-    }).sort((a, b) => a.name.localeCompare(b.name, "ko-KR"));
-
-    Object.entries(categoryZones).forEach(([category, zone]) => {
-      const group = zone.closest(".category-group");
-      const matchingSites = filteredSites.filter(
-        (site) => site.category === category,
-      );
-
-      zone.replaceChildren(...matchingSites.map((site) => createListItem(site)));
-
-      visibleCount += matchingSites.length;
-      if (group) group.hidden = Boolean(query && matchingSites.length === 0);
-    });
-
-    if (searchEmptyMessage) {
-      searchEmptyMessage.hidden = !query || visibleCount > 0;
+  function initShortcutGuide() {
+    const shortcutGuide = document.getElementById("shortcut-guide");
+    if (shortcutGuide && chrome.commands?.getAll) {
+      chrome.commands.getAll((commands) => {
+        const actionCommand = commands.find(
+          (command) => command.name === "_execute_action",
+        );
+        shortcutGuide.hidden = Boolean(actionCommand?.shortcut);
+      });
     }
+
+    document.querySelectorAll(".shortcut-link").forEach((button) => {
+      button.addEventListener("click", () => {
+        const url = button.dataset.shortcutUrl;
+        if (!url) return;
+
+        chrome.tabs.create({ url }, () => {
+          if (!chrome.runtime.lastError) return;
+
+          navigator.clipboard.writeText(url)
+            .then(() => {
+              alert(`${url} 주소를 복사했습니다. 주소창에 붙여넣어 이동해주세요.`);
+            })
+            .catch(() => {
+              alert(`${url} 주소를 직접 복사하여 주소창에 붙여넣어 이동해주세요.`);
+            });
+        });
+      });
+    });
   }
 
-  function sortZoneAlphabetically(zone) {
-    const items = Array.from(zone.querySelectorAll(".list-item"));
-    items.sort((a, b) => {
-      const nameA = a.querySelector(".site-name").textContent;
-      const nameB = b.querySelector(".site-name").textContent;
-      return nameA.localeCompare(nameB, "ko-KR");
-    });
-    items.forEach((item) => zone.appendChild(item));
-  }
-
-  chrome.storage.local.get(["userOrder"], (result) => {
-    const activeOrder =
-      result.userOrder || LinKHUShared.getDefaultOrder(MASTER_SITE_LIST);
-
-    MASTER_SITE_LIST.filter((site) => activeOrder.includes(site.id)).forEach(
-      (site) => {
-        const el = createListItem(site);
-        activeList.appendChild(el);
-      },
-    );
-
-    activeOrder.forEach((id) => {
-      const item = activeList.querySelector(`[data-id="${id}"]`);
-      if (item) activeList.appendChild(item);
-    });
-
-    updateSearchResults();
-  });
+  const listItemById = new Map();
 
   function createListItem(site) {
     if (listItemById.has(site.id)) {
@@ -151,154 +83,262 @@ document.addEventListener("DOMContentLoaded", () => {
 
     el.append(dragHandle, icon, siteName);
 
-    addDragEvents(el);
+    DragController.addDragEvents(el);
     listItemById.set(site.id, el);
     return el;
   }
 
-  if (searchInput) {
-    searchInput.addEventListener("input", updateSearchResults);
-  }
+  // 검색 입력과 왼쪽 카테고리 목록 렌더링을 담당한다.
+  const SearchPanel = {
+    siteSearchTextById: new Map(
+      MASTER_SITE_LIST.map((site) => [
+        site.id,
+        LinKHUShared.normalize(`${site.name}${site.id}${site.category}`),
+      ]),
+    ),
 
-  document.addEventListener("keydown", (e) => {
-    if (
-      e.target.tagName === "INPUT" ||
-      e.target.tagName === "TEXTAREA" ||
-      e.target.tagName === "SELECT" ||
-      e.target.isContentEditable ||
-      e.ctrlKey ||
-      e.altKey ||
-      e.metaKey ||
-      e.repeat
-    ) {
-      return;
-    }
+    matchesSearch(site, query) {
+      return this.siteSearchTextById.get(site.id).includes(query);
+    },
 
-    if (e.key === "/") {
-      e.preventDefault();
-      searchInput?.focus();
-    }
-  });
+    getActiveIds() {
+      return new Set(
+        Array.from(activeList.querySelectorAll(".list-item")).map(
+          (item) => item.dataset.id,
+        ),
+      );
+    },
 
-  saveBtn.addEventListener("click", () => {
-    const activeItems = activeList.querySelectorAll(".list-item");
-    const newOrder = Array.from(activeItems).map((item) => item.dataset.id);
+    update() {
+      const query = LinKHUShared.normalize(searchInput?.value);
+      const activeIds = this.getActiveIds();
+      let visibleCount = 0;
 
-    OptionsStorage.saveUserOrder(newOrder, (error) => {
-      if (error) {
-        console.error("설정 저장 실패:", error);
-        alert("설정을 저장하지 못했습니다. 잠시 후 다시 시도해주세요.");
+      const filteredSites = MASTER_SITE_LIST.filter((site) => {
+        if (activeIds.has(site.id)) return false;
+        return !query || this.matchesSearch(site, query);
+      }).sort((a, b) => compareSiteNames(a.name, b.name));
+
+      Object.entries(categoryZones).forEach(([category, zone]) => {
+        const group = zone.closest(".category-group");
+        const matchingSites = filteredSites.filter(
+          (site) => site.category === category,
+        );
+
+        zone.replaceChildren(...matchingSites.map((site) => createListItem(site)));
+
+        visibleCount += matchingSites.length;
+        if (group) group.hidden = Boolean(query && matchingSites.length === 0);
+      });
+
+      if (searchEmptyMessage) {
+        searchEmptyMessage.hidden = !query || visibleCount > 0;
+      }
+    },
+
+    sortZone(zone) {
+      const items = Array.from(zone.querySelectorAll(".list-item"));
+      items.sort((a, b) =>
+        compareSiteNames(
+          a.querySelector(".site-name").textContent,
+          b.querySelector(".site-name").textContent,
+        ),
+      );
+      items.forEach((item) => zone.appendChild(item));
+    },
+
+    init() {
+      if (searchInput) {
+        searchInput.addEventListener("input", () => this.update());
+      }
+    },
+  };
+
+  // 드래그 앤 드롭 이동과 스크롤 영역 자동 스크롤을 담당한다.
+  const DragController = {
+    SCROLL_SPEED: 8,
+    SCROLL_SENSITIVITY: 40,
+    draggedItem: null,
+    scrollInterval: null,
+    // 0: 정지, -1: 위, 1: 아래
+    scrollDirection: 0,
+    currentScrollArea: null,
+    scrollAreaRect: null,
+
+    addDragEvents(item) {
+      const controller = this;
+
+      item.addEventListener("dragstart", function () {
+        controller.draggedItem = this;
+        setTimeout(() => this.classList.add("dragging"), 0);
+      });
+
+      item.addEventListener("dragend", function () {
+        this.classList.remove("dragging");
+        controller.draggedItem = null;
+        controller.stopAutoScroll();
+        controller.currentScrollArea = null;
+        controller.scrollAreaRect = null;
+        SearchPanel.update();
+      });
+    },
+
+    stopAutoScroll() {
+      clearInterval(this.scrollInterval);
+      this.scrollInterval = null;
+      this.scrollDirection = 0;
+    },
+
+    handleAutoScroll(event) {
+      const area = event.target.closest(".scroll-area");
+      // 스크롤 영역 밖으로 잠깐 벗어나도 직전 영역 기준으로 자동 스크롤을 이어간다.
+      if (area && area !== this.currentScrollArea) {
+        this.currentScrollArea = area;
+        // dragover 반복 호출 중 레이아웃 계산을 줄이기 위해 영역이 바뀔 때만 갱신한다.
+        this.scrollAreaRect = area.getBoundingClientRect();
+      }
+
+      if (!this.currentScrollArea || !this.scrollAreaRect) return;
+
+      let newDirection = 0;
+
+      if (event.clientY < this.scrollAreaRect.top + this.SCROLL_SENSITIVITY) {
+        newDirection = -1;
+      } else if (
+        event.clientY > this.scrollAreaRect.bottom - this.SCROLL_SENSITIVITY
+      ) {
+        newDirection = 1;
+      }
+
+      if (this.scrollDirection !== newDirection) {
+        this.stopAutoScroll();
+        this.scrollDirection = newDirection;
+
+        if (newDirection !== 0) {
+          this.scrollInterval = setInterval(() => {
+            this.currentScrollArea.scrollTop +=
+              this.scrollDirection * this.SCROLL_SPEED;
+          }, 16);
+        }
+      }
+    },
+
+    getDragAfterElement(container, y) {
+      const draggableElements = [
+        ...container.querySelectorAll(".list-item:not(.dragging)"),
+      ];
+
+      return draggableElements.reduce(
+        (closest, child) => {
+          const box = child.getBoundingClientRect();
+          const offset = y - box.top - box.height / 2;
+          if (offset < 0 && offset > closest.offset) {
+            return { offset: offset, element: child };
+          } else {
+            return closest;
+          }
+        },
+        { offset: Number.NEGATIVE_INFINITY },
+      ).element;
+    },
+
+    init() {
+      document.addEventListener("dragover", (e) => {
+        if (!this.draggedItem) return;
+        this.handleAutoScroll(e);
+      });
+
+      activeList.addEventListener("dragover", (e) => {
+        e.preventDefault();
+        const currentDrag = document.querySelector(".dragging");
+        if (!currentDrag) return;
+
+        const afterElement = this.getDragAfterElement(activeList, e.clientY);
+        if (afterElement == null) {
+          activeList.appendChild(currentDrag);
+        } else {
+          activeList.insertBefore(currentDrag, afterElement);
+        }
+      });
+
+      leftColumn.addEventListener("dragover", (e) => {
+        e.preventDefault();
+        const currentDrag = document.querySelector(".dragging");
+        if (!currentDrag) return;
+
+        const targetZone = categoryZones[currentDrag.dataset.category];
+
+        if (currentDrag.parentNode !== targetZone) {
+          targetZone.appendChild(currentDrag);
+          SearchPanel.sortZone(targetZone);
+        }
+      });
+    },
+  };
+
+  function initSearchShortcut() {
+    document.addEventListener("keydown", (e) => {
+      if (
+        e.target.tagName === "INPUT" ||
+        e.target.tagName === "TEXTAREA" ||
+        e.target.tagName === "SELECT" ||
+        e.target.isContentEditable ||
+        e.ctrlKey ||
+        e.altKey ||
+        e.metaKey ||
+        e.repeat
+      ) {
         return;
       }
 
-      alert("성공적으로 저장되었습니다.");
-    });
-  });
-
-  let draggedItem = null;
-  let scrollInterval = null;
-  // 0: 정지, -1: 위, 1: 아래
-  let scrollDirection = 0;
-
-  function addDragEvents(item) {
-    item.addEventListener("dragstart", function () {
-      draggedItem = this;
-      setTimeout(() => this.classList.add("dragging"), 0);
-    });
-
-    item.addEventListener("dragend", function () {
-      this.classList.remove("dragging");
-      draggedItem = null;
-      clearInterval(scrollInterval);
-      scrollInterval = null;
-      scrollDirection = 0;
-      currentScrollArea = null;
-      scrollAreaRect = null;
-      updateSearchResults();
-    });
-  }
-
-  const SCROLL_SPEED = 8;
-  const SCROLL_SENSITIVITY = 40;
-  let currentScrollArea = null;
-  let scrollAreaRect = null;
-
-  document.addEventListener("dragover", (e) => {
-    if (!draggedItem) return;
-
-    const area = e.target.closest(".scroll-area");
-    // 스크롤 영역 밖으로 잠깐 벗어나도 직전 영역 기준으로 자동 스크롤을 이어간다.
-    if (area && area !== currentScrollArea) {
-      currentScrollArea = area;
-      // dragover 반복 호출 중 레이아웃 계산을 줄이기 위해 영역이 바뀔 때만 갱신한다.
-      scrollAreaRect = area.getBoundingClientRect();
-    }
-    
-    if (!currentScrollArea || !scrollAreaRect) return;
-
-    let newDirection = 0;
-    
-    if (e.clientY < scrollAreaRect.top + SCROLL_SENSITIVITY) {
-      newDirection = -1;
-    } else if (e.clientY > scrollAreaRect.bottom - SCROLL_SENSITIVITY) {
-      newDirection = 1;
-    }
-
-    if (scrollDirection !== newDirection) {
-      clearInterval(scrollInterval);
-      scrollInterval = null;
-      scrollDirection = newDirection;
-
-      if (scrollDirection !== 0) {
-        scrollInterval = setInterval(() => {
-          currentScrollArea.scrollTop += scrollDirection * SCROLL_SPEED;
-        }, 16);
+      if (e.key === "/") {
+        e.preventDefault();
+        searchInput?.focus();
       }
-    }
-  });
-
-  activeList.addEventListener("dragover", function (e) {
-    e.preventDefault();
-    const currentDrag = document.querySelector(".dragging");
-    if (!currentDrag) return;
-
-    const afterElement = getDragAfterElement(activeList, e.clientY);
-    if (afterElement == null) {
-      activeList.appendChild(currentDrag);
-    } else {
-      activeList.insertBefore(currentDrag, afterElement);
-    }
-  });
-
-  leftColumn.addEventListener("dragover", function (e) {
-    e.preventDefault();
-    const currentDrag = document.querySelector(".dragging");
-    if (!currentDrag) return;
-
-    const targetZone = categoryZones[currentDrag.dataset.category];
-
-    if (currentDrag.parentNode !== targetZone) {
-      targetZone.appendChild(currentDrag);
-      sortZoneAlphabetically(targetZone);
-    }
-  });
-
-  function getDragAfterElement(container, y) {
-    const draggableElements = [
-      ...container.querySelectorAll(".list-item:not(.dragging)"),
-    ];
-
-    return draggableElements.reduce(
-      (closest, child) => {
-        const box = child.getBoundingClientRect();
-        const offset = y - box.top - box.height / 2;
-        if (offset < 0 && offset > closest.offset) {
-          return { offset: offset, element: child };
-        } else {
-          return closest;
-        }
-      },
-      { offset: Number.NEGATIVE_INFINITY },
-    ).element;
+    });
   }
+
+  function initSaveButton() {
+    saveBtn.addEventListener("click", () => {
+      const activeItems = activeList.querySelectorAll(".list-item");
+      const newOrder = Array.from(activeItems).map((item) => item.dataset.id);
+
+      OptionsStorage.saveUserOrder(newOrder, (error) => {
+        if (error) {
+          console.error("설정 저장 실패:", error);
+          alert("설정을 저장하지 못했습니다. 잠시 후 다시 시도해주세요.");
+          return;
+        }
+
+        alert("성공적으로 저장되었습니다.");
+      });
+    });
+  }
+
+  function loadActiveList() {
+    chrome.storage.local.get(["userOrder"], (result) => {
+      const activeOrder =
+        result.userOrder || LinKHUShared.getDefaultOrder(MASTER_SITE_LIST);
+
+      MASTER_SITE_LIST.filter((site) => activeOrder.includes(site.id)).forEach(
+        (site) => {
+          activeList.appendChild(createListItem(site));
+        },
+      );
+
+      activeOrder.forEach((id) => {
+        const item = activeList.querySelector(`[data-id="${id}"]`);
+        if (item) activeList.appendChild(item);
+      });
+
+      SearchPanel.update();
+    });
+  }
+
+  initShortcutGuide();
+  SearchPanel.init();
+  DragController.init();
+  initSearchShortcut();
+  initSaveButton();
+  loadActiveList();
 });


### PR DESCRIPTION
## 📝 요약
> 300줄짜리 DOMContentLoaded 단일 클로저였던 options.js를 역할별 객체(SearchPanel, DragController)와 초기화 함수들로 재구성했습니다. 동작 변경은 없습니다.

## ⚙️ 작업 사항
- [x] `SearchPanel`: 검색 인덱스, 필터, 카테고리 존 렌더, 존 정렬
- [x] `DragController`: 드래그 상태, 자동 스크롤, dragover 핸들러
- [x] `initShortcutGuide` / `initSearchShortcut` / `initSaveButton` / `loadActiveList` 분리
- [x] 정렬 comparator 중복 통합 (`compareSiteNames`)

## 📌 관련 이슈
- Close #77

## 🧪 테스트 결과
- `npm run build` 통과 (tests 16 pass / 0 fail, 데이터 검증 통과, 128개 파일 패키징)
- `node --check src/options.js` 통과

## 💡 리뷰 포인트
- 드래그 자동 스크롤의 setInterval 콜백이 클로저 변수 대신 `this.currentScrollArea`를 읽도록 바뀌었지만, 원본도 변수 최신값을 읽는 구조라 의미가 동일합니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요? (자동 테스트 통과, 드래그 앤 드롭은 머지 후 확장 로드로 확인 권장)
- [ ] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [ ] 문서(Wiki, API Docs 등)를 업데이트했나요? (해당 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)