### PR TITLE
feat: 팝업 검색에 랜딩 페이지와 동일한 랭킹 적용

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -78,11 +78,10 @@ const App = {
         .filter(Boolean);
 
       const query = LinKHUShared.normalize(this.searchQuery);
-      const sourceSites = query ? MASTER_SITE_LIST : configuredSites;
       const displaySites = this.getUniqueSites(
-        sourceSites.filter(
-          (site) => !query || LinKHUShared.matchesSearch(site, query),
-        ),
+        query
+          ? LinKHUShared.rankSites(MASTER_SITE_LIST, this.searchQuery)
+          : configuredSites,
       );
       this.currentItems = displaySites;
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -14,6 +14,36 @@ const LinKHUShared = {
     );
   },
 
+  // 점수가 낮을수록 상위 노출. 랜딩 페이지(docs/landing.js)의 scoreService와
+  // 같은 규칙을 유지해야 팝업과 랜딩의 검색 결과 순서가 일치한다.
+  scoreSite(site, normalizedQuery) {
+    const name = this.normalize(site.name);
+    const id = this.normalize(site.id);
+    const category = this.normalize(site.category);
+
+    if (name.startsWith(normalizedQuery)) return 0;
+    if (name.includes(normalizedQuery)) return 1;
+    if (id.startsWith(normalizedQuery)) return 2;
+    if (id.includes(normalizedQuery)) return 3;
+    if (category.includes(normalizedQuery)) return 4;
+    return Number.POSITIVE_INFINITY;
+  },
+
+  rankSites(sites, query) {
+    const normalizedQuery = this.normalize(query);
+    if (!normalizedQuery) return [];
+
+    return sites
+      .map((site, index) => ({
+        site,
+        index,
+        score: this.scoreSite(site, normalizedQuery),
+      }))
+      .filter(({ score }) => Number.isFinite(score))
+      .sort((left, right) => left.score - right.score || left.index - right.index)
+      .map(({ site }) => site);
+  },
+
   getDefaultOrder(siteList) {
     return siteList
       .filter((site) => site.category === "공통")

--- a/tests/shared.test.js
+++ b/tests/shared.test.js
@@ -21,6 +21,50 @@ test("shared matchesSearch matches name, id, and category", () => {
   assert.equal(LinKHUShared.matchesSearch(site, "없는검색어"), false);
 });
 
+test("shared rankSites orders by name prefix, name, id, then category", () => {
+  const sites = [
+    { id: "swcon", name: "소프트웨어융합학과", category: "학과" },
+    { id: "software", name: "소프트웨어 융합대학", category: "단과대" },
+    { id: "cs", name: "컴퓨터공학부", category: "학과" },
+  ];
+
+  assert.deepEqual(
+    LinKHUShared.rankSites(sites, "소프트웨어").map((site) => site.id),
+    ["swcon", "software"],
+  );
+  assert.deepEqual(
+    LinKHUShared.rankSites(sites, "cs").map((site) => site.id),
+    ["cs"],
+  );
+  assert.deepEqual(
+    LinKHUShared.rankSites(sites, "학과").map((site) => site.id),
+    ["swcon", "cs"],
+  );
+  assert.deepEqual(LinKHUShared.rankSites(sites, "  "), []);
+});
+
+test("shared rankSites matches landing search order", () => {
+  const { searchServices } = require("../docs/landing");
+  const services = [
+    { id: "info21", name: "인포21", category: "공통" },
+    { id: "ecampus", name: "e-Campus", category: "공통" },
+    { id: "sugang", name: "수강신청", category: "공통" },
+    { id: "software", name: "소프트웨어융합대학", category: "단과대" },
+    { id: "swcon", name: "소프트웨어융합학과", category: "학과" },
+    { id: "cs", name: "컴퓨터공학부", category: "학과" },
+  ];
+
+  ["소프트웨어", "E campus", "cs", "학과", "공통"].forEach((query) => {
+    assert.deepEqual(
+      LinKHUShared.rankSites(services, query)
+        .slice(0, 5)
+        .map((service) => service.id),
+      searchServices(services, query).map((service) => service.id),
+      `query "${query}" should rank identically on popup and landing`,
+    );
+  });
+});
+
 test("shared getDefaultOrder keeps 공통 sites in list order", () => {
   const sites = [
     { id: "a", category: "공통" },


### PR DESCRIPTION
## 📝 요약
> 팝업 검색이 데이터 순서 그대로 결과를 보여주던 것을, 랜딩 페이지와 동일한 랭킹 규칙(이름 접두 일치 > 이름 포함 > id 접두 > id 포함 > 카테고리)으로 정렬하도록 통일했습니다. Enter로 첫 항목을 여는 동작의 정확도가 올라갑니다.

## ⚙️ 작업 사항
- [x] `shared.js`에 `scoreSite`, `rankSites` 추가
- [x] 팝업 검색 결과를 `rankSites` 순서로 표시
- [x] 랭킹 단위 테스트 + 랜딩 `searchServices` 패리티 테스트 추가

## 📌 관련 이슈
- Close #79

## 🧪 테스트 결과
- `npm run build` 통과 (tests 18 pass / 0 fail, 데이터 검증 통과, 128개 파일 패키징)
- 패리티 테스트: "소프트웨어", "E campus", "cs", "학과", "공통" 5개 검색어에서 팝업/랜딩 순서 일치 확인

## 💡 리뷰 포인트
- 검색 결과가 없을 때의 동작(빈 목록 + 안내 문구)은 기존과 동일합니다.
- 검색어가 없을 때는 기존처럼 사용자 지정 순서(userOrder)를 그대로 보여줍니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [ ] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [ ] 문서(Wiki, API Docs 등)를 업데이트했나요? (해당 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)