### PR TITLE
feat: 팝업·설정 페이지에 홈페이지 링크와 문의 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ git push origin "v$VERSION"
 Chrome Web Store 자동 배포는 [Chrome Web Store Automation](./docs/chrome-web-store-automation.md)을 따릅니다.
 Firefox Add-ons 자동 배포는 [Firefox Add-ons Automation](./docs/firefox-addons-automation.md)을 따릅니다.
 Whale Store 배포는 [Whale Store Automation Research](./docs/whale-store-automation.md)에 따라 수동 절차를 유지합니다.
+팝업/설정 페이지의 문의 기능 연결은 [문의 채널 설정 가이드](./docs/feedback-setup.md)를 따릅니다.
 
 ## 🐛 버그 제보 및 기여
 

--- a/docs/feedback-setup.md
+++ b/docs/feedback-setup.md
@@ -1,0 +1,49 @@
+# 문의 채널(Google Forms) 설정 가이드
+
+팝업/설정 페이지의 "문의하기"는 Google Forms의 `formResponse` 엔드포인트로 백그라운드 전송하는 방식입니다. 확장 소스에 비밀값이 들어가지 않아 공개 저장소에 안전하고, 폼의 이메일 알림을 켜면 응답이 올 때마다 Gmail로 바로 알림을 받을 수 있습니다.
+
+## 1. Google Form 만들기
+
+1. [Google Forms](https://forms.google.com)에서 새 폼을 만듭니다. 제목 예: `LinKHU 문의`.
+2. 질문을 1개 추가합니다.
+   - 유형: **장문형**
+   - 질문: `문의 내용`
+   - 필수 여부: 필수
+3. 설정 탭에서 "이메일 주소 수집"은 **사용 안 함**으로 둡니다. (수집하면 확장에서 보내는 익명 전송이 필수 필드 누락으로 저장되지 않습니다.)
+
+## 2. 이메일 알림 켜기
+
+1. 폼의 **응답** 탭 → ⋮ 메뉴 → **새 응답에 대한 이메일 알림 받기**를 켭니다.
+2. 이후 문의가 들어올 때마다 폼 소유자 계정의 Gmail로 알림이 옵니다. 휴대폰 Gmail 앱 알림을 켜두면 푸시로도 받을 수 있습니다.
+
+## 3. 전송 주소와 entry ID 확인
+
+1. 폼 편집 화면에서 ⋮ 메뉴 → **미리 채워진 링크 받기**를 선택합니다.
+2. 문의 내용 칸에 아무 값이나 입력하고 **링크 받기 → 링크 복사**를 누릅니다.
+3. 복사한 URL에서 두 값을 확인합니다.
+   - `https://docs.google.com/forms/d/e/<긴 ID>/viewform?usp=pp_url&entry.123456789=...`
+   - **formUrl**: `viewform` 앞부분을 그대로 쓰되 `viewform`을 `formResponse`로 바꾼 값
+     - 예: `https://docs.google.com/forms/d/e/<긴 ID>/formResponse`
+   - **messageEntry**: 쿼리의 `entry.123456789` 부분
+
+## 4. 확장에 연결
+
+`src/feedback.js`의 `FEEDBACK_CONFIG`에 두 값을 채웁니다.
+
+```js
+const FEEDBACK_CONFIG = {
+  formUrl: "https://docs.google.com/forms/d/e/<긴 ID>/formResponse",
+  messageEntry: "entry.123456789",
+};
+```
+
+설정 전까지 문의 버튼을 누르면 "문의 채널이 아직 준비되지 않았습니다" 안내가 표시됩니다.
+
+## 5. 동작 확인
+
+1. 확장을 다시 로드한 뒤 팝업 → 문의하기 → 테스트 문의를 전송합니다.
+2. 폼의 **응답** 탭에 내용이 도착했는지, 알림 메일이 왔는지 확인합니다.
+
+## 참고: 왜 no-cors 전송인가
+
+Google Forms는 CORS 응답 헤더를 제공하지 않아 응답 본문을 읽을 수 없습니다. 그래서 `fetch(..., { mode: "no-cors" })`로 보내고 네트워크 오류가 없으면 전송 성공으로 간주합니다. entry ID를 잘못 넣으면 오류 없이 응답만 저장되지 않으므로, 설정 후 반드시 5번의 테스트 전송으로 확인하세요.

--- a/src/feedback.js
+++ b/src/feedback.js
@@ -1,0 +1,81 @@
+// 문의 전송 설정. docs/feedback-setup.md 절차대로 Google Form을 만든 뒤
+// 아래 두 값을 채우면 팝업/설정 페이지의 문의 기능이 활성화된다.
+// Google Forms 전송 주소는 공개돼도 안전하므로 확장 소스에 그대로 둔다.
+const FEEDBACK_CONFIG = {
+  // 예: "https://docs.google.com/forms/d/e/1FAIpQL.../formResponse"
+  formUrl: "",
+  // 예: "entry.123456789" (문의 내용 장문형 질문의 entry ID)
+  messageEntry: "",
+};
+
+const Feedback = {
+  isConfigured(config = FEEDBACK_CONFIG) {
+    return Boolean(config.formUrl && config.messageEntry);
+  },
+
+  createSubmission(message, config = FEEDBACK_CONFIG) {
+    return {
+      url: config.formUrl,
+      body: new URLSearchParams({ [config.messageEntry]: message }),
+    };
+  },
+
+  // Google Forms는 CORS 응답 헤더를 주지 않으므로 no-cors로 보내고,
+  // 네트워크 오류가 없으면 전송된 것으로 간주한다.
+  async submit(message) {
+    const { url, body } = this.createSubmission(message);
+    await fetch(url, { method: "POST", mode: "no-cors", body });
+  },
+};
+
+// 팝업과 설정 페이지가 같은 요소 id를 사용하므로 한 곳에서 와이어링한다.
+function initFeedbackForm() {
+  const toggle = document.getElementById("feedback-toggle");
+  const panel = document.getElementById("feedback-panel");
+  const messageInput = document.getElementById("feedback-message");
+  const sendBtn = document.getElementById("feedback-send");
+  const status = document.getElementById("feedback-status");
+
+  if (!toggle || !panel || !messageInput || !sendBtn || !status) return;
+
+  toggle.addEventListener("click", () => {
+    panel.hidden = !panel.hidden;
+    if (!panel.hidden) messageInput.focus();
+  });
+
+  sendBtn.addEventListener("click", async () => {
+    const message = messageInput.value.trim();
+    if (!message) {
+      status.textContent = "문의 내용을 입력해주세요.";
+      return;
+    }
+
+    if (!Feedback.isConfigured()) {
+      status.textContent =
+        "문의 채널이 아직 준비되지 않았습니다. 잠시 후 다시 시도해주세요.";
+      return;
+    }
+
+    sendBtn.disabled = true;
+    status.textContent = "전송 중...";
+
+    try {
+      await Feedback.submit(message);
+      messageInput.value = "";
+      status.textContent = "전송했습니다. 소중한 의견 감사합니다!";
+    } catch (error) {
+      console.error("문의 전송 실패:", error);
+      status.textContent = "전송에 실패했습니다. 잠시 후 다시 시도해주세요.";
+    } finally {
+      sendBtn.disabled = false;
+    }
+  });
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", initFeedbackForm);
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = Feedback;
+}

--- a/src/options.css
+++ b/src/options.css
@@ -266,3 +266,87 @@ h1 {
 .save-btn:hover {
   background-color: #7a1a29;
 }
+
+.options-footer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+  flex-shrink: 0;
+}
+
+.footer-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  font-size: 13px;
+  color: #888888;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.footer-link:hover {
+  color: #9d2235;
+  text-decoration: underline;
+}
+
+.footer-divider {
+  color: #cccccc;
+  font-size: 12px;
+}
+
+.feedback-panel {
+  margin-top: 12px;
+  flex-shrink: 0;
+}
+
+.feedback-panel textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  border: 1px solid #dddddd;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #333333;
+  font-family: inherit;
+  font-size: 13px;
+  resize: vertical;
+}
+
+.feedback-panel textarea:focus {
+  outline: none;
+  border-color: #9d2235;
+  box-shadow: 0 0 0 3px rgba(157, 34, 53, 0.12);
+}
+
+.feedback-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 6px;
+}
+
+.feedback-send {
+  padding: 6px 16px;
+  border: none;
+  border-radius: 6px;
+  background: #9d2235;
+  color: #ffffff;
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.feedback-send:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.feedback-status {
+  margin: 6px 0 0;
+  min-height: 15px;
+  color: #777777;
+  font-size: 12px;
+  text-align: right;
+}

--- a/src/options.html
+++ b/src/options.html
@@ -89,10 +89,40 @@
       </div>
 
       <button id="save-btn" class="save-btn">변경사항 저장하기</button>
+
+      <footer class="options-footer">
+        <a
+          class="footer-link"
+          href="https://kangkyunghyun.github.io/LinKHU/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >LinKHU 홈페이지</a
+        >
+        <span class="footer-divider" aria-hidden="true">·</span>
+        <button id="feedback-toggle" class="footer-link" type="button">
+          문의하기
+        </button>
+      </footer>
+
+      <div id="feedback-panel" class="feedback-panel" hidden>
+        <textarea
+          id="feedback-message"
+          rows="3"
+          placeholder="불편한 점이나 추가하고 싶은 서비스를 적어주세요."
+          aria-label="문의 내용"
+        ></textarea>
+        <div class="feedback-actions">
+          <button id="feedback-send" class="feedback-send" type="button">
+            보내기
+          </button>
+        </div>
+        <p id="feedback-status" class="feedback-status" role="status"></p>
+      </div>
     </div>
 
     <script src="data.js"></script>
     <script src="shared.js"></script>
+    <script src="feedback.js"></script>
     <script src="options.js"></script>
   </body>
 </html>

--- a/src/popup.css
+++ b/src/popup.css
@@ -154,6 +154,88 @@ header h1 {
   flex-shrink: 0;
 }
 
+.popup-footer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.footer-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  font-size: 11.5px;
+  color: #888888;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.footer-link:hover {
+  color: var(--primary-color);
+  text-decoration: underline;
+}
+
+.footer-divider {
+  color: #cccccc;
+  font-size: 11px;
+}
+
+.feedback-panel {
+  margin-top: 12px;
+}
+
+.feedback-panel textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--card-bg);
+  color: var(--text-main);
+  font-family: inherit;
+  font-size: 12.5px;
+  resize: vertical;
+}
+
+.feedback-panel textarea:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(157, 34, 53, 0.12);
+}
+
+.feedback-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 6px;
+}
+
+.feedback-send {
+  padding: 5px 14px;
+  border: none;
+  border-radius: 6px;
+  background: var(--primary-color);
+  color: #ffffff;
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.feedback-send:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.feedback-status {
+  margin: 6px 0 0;
+  min-height: 14px;
+  color: #777777;
+  font-size: 11.5px;
+  text-align: right;
+}
+
 .grid-item span {
   font-size: 11.5px;
   color: var(--text-main);

--- a/src/popup.html
+++ b/src/popup.html
@@ -76,11 +76,40 @@
 
       <p id="empty-message" class="empty-message" hidden>검색 결과 없음</p>
       <div id="grid-container" class="grid-container"></div>
+
+      <div id="feedback-panel" class="feedback-panel" hidden>
+        <textarea
+          id="feedback-message"
+          rows="3"
+          placeholder="불편한 점이나 추가하고 싶은 서비스를 적어주세요."
+          aria-label="문의 내용"
+        ></textarea>
+        <div class="feedback-actions">
+          <button id="feedback-send" class="feedback-send" type="button">
+            보내기
+          </button>
+        </div>
+        <p id="feedback-status" class="feedback-status" role="status"></p>
+      </div>
+
+      <footer class="popup-footer">
+        <a
+          id="homepage-link"
+          class="footer-link"
+          href="https://kangkyunghyun.github.io/LinKHU/"
+          >홈페이지</a
+        >
+        <span class="footer-divider" aria-hidden="true">·</span>
+        <button id="feedback-toggle" class="footer-link" type="button">
+          문의하기
+        </button>
+      </footer>
     </div>
 
     <script src="data.js"></script>
     <script src="shared.js"></script>
     <script src="version.js"></script>
+    <script src="feedback.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -111,6 +111,16 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
+  // 팝업 안에서 링크를 그대로 열면 팝업 화면이 이동하므로 새 탭으로 연다.
+  const homepageLink = document.getElementById("homepage-link");
+  if (homepageLink) {
+    homepageLink.addEventListener("click", (e) => {
+      e.preventDefault();
+      chrome.tabs.create({ url: homepageLink.href, active: true });
+      window.close();
+    });
+  }
+
   const searchInput = document.getElementById("service-search");
   if (searchInput) {
     searchInput.addEventListener("input", (e) => {

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -1,0 +1,32 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const Feedback = require("../src/feedback");
+
+test("feedback stays disabled until the form is configured", () => {
+  assert.equal(Feedback.isConfigured({ formUrl: "", messageEntry: "" }), false);
+  assert.equal(
+    Feedback.isConfigured({
+      formUrl: "https://docs.google.com/forms/d/e/FORM/formResponse",
+      messageEntry: "",
+    }),
+    false,
+  );
+  assert.equal(
+    Feedback.isConfigured({
+      formUrl: "https://docs.google.com/forms/d/e/FORM/formResponse",
+      messageEntry: "entry.123456789",
+    }),
+    true,
+  );
+});
+
+test("feedback submission targets the configured form entry", () => {
+  const { url, body } = Feedback.createSubmission("팝업이 열리지 않아요", {
+    formUrl: "https://docs.google.com/forms/d/e/FORM/formResponse",
+    messageEntry: "entry.123456789",
+  });
+
+  assert.equal(url, "https://docs.google.com/forms/d/e/FORM/formResponse");
+  assert.equal(body.get("entry.123456789"), "팝업이 열리지 않아요");
+});


### PR DESCRIPTION
## 📝 요약
> 팝업과 설정 페이지 하단에 랜딩 홈페이지 링크와 "문의하기"를 추가했습니다. 문의는 GitHub 계정 없이 빈칸에 입력해 바로 보낼 수 있고, Google Forms `formResponse`로 백그라운드 전송되어 폼 이메일 알림으로 소유자에게 즉시 도착합니다.

## ⚙️ 작업 사항
- [x] 팝업 하단 푸터: 홈페이지 링크(새 탭) + 문의하기 토글 패널
- [x] 설정 페이지 하단: 동일한 링크/문의 폼
- [x] `src/feedback.js`: no-cors 전송, 미설정/빈 입력/실패 상태 처리 (비밀값 없음 — 공개 소스 안전)
- [x] `docs/feedback-setup.md` 설정 가이드 + README 링크
- [x] `tests/feedback.test.js` 단위 테스트

## 📌 관련 이슈
- Close #81

## 🧪 테스트 결과
- `npm run build` 통과 (tests 20 pass / 0 fail, 데이터 검증 통과, 129개 파일 패키징)
- 수동 확인 필요: `FEEDBACK_CONFIG`에 실제 폼 값을 넣은 뒤 docs/feedback-setup.md 5번 절차로 테스트 전송

## 💡 리뷰 포인트
- Google Forms는 CORS 응답을 주지 않아 no-cors로 보내고 네트워크 오류가 없으면 성공으로 간주합니다. entry ID 오설정은 감지할 수 없으므로 최초 1회 테스트 전송이 필요합니다.
- `FEEDBACK_CONFIG`가 비어 있는 동안에는 "문의 채널이 아직 준비되지 않았습니다" 안내만 표시됩니다(전송 시도 없음).

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [ ] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요?

🤖 Generated with [Claude Code](https://claude.com/claude-code)