### PR TITLE
feat: 문의 채널 Google Form 연결

### DIFF
--- a/src/feedback.js
+++ b/src/feedback.js
@@ -2,13 +2,12 @@
 // 아래 두 값을 채우면 팝업/설정 페이지의 문의 기능이 활성화된다.
 // Google Forms 전송 주소는 공개돼도 안전하므로 확장 소스에 그대로 둔다.
 const FEEDBACK_CONFIG = {
-  // 예: "https://docs.google.com/forms/d/e/1FAIpQL.../formResponse"
-  formUrl: "",
-  // 예: "entry.123456789" (문의 내용 장문형 질문의 entry ID)
-  messageEntry: "",
-  // 예: "entry.987654321" (답변 받을 이메일 단답형 질문의 entry ID, 선택)
-  // 비워두면 이메일 입력란이 표시되지 않는다.
-  emailEntry: "",
+  formUrl:
+    "https://docs.google.com/forms/d/e/1FAIpQLSei30Rr122YHmLlixTDEaWtUPY_pM-EQ20kBMLvyu-52Q6IZQ/formResponse",
+  // 문의 내용 장문형 질문의 entry ID
+  messageEntry: "entry.1096769292",
+  // 답변 받을 이메일 단답형 질문의 entry ID. 비워두면 이메일 입력란이 표시되지 않는다.
+  emailEntry: "entry.491031779",
 };
 
 const Feedback = {


### PR DESCRIPTION
## 📝 요약
> #81/#83에서 만든 문의 기능에 실제 Google Form을 연결했습니다. 이제 팝업/설정의 문의하기가 활성화되고, 답변용 이메일 입력란도 표시됩니다.

## ⚙️ 작업 사항
- [x] `FEEDBACK_CONFIG`에 formUrl, messageEntry(entry.1096769292), emailEntry(entry.491031779) 연결

## 📌 관련 이슈
- Close #85

## 🧪 테스트 결과
- `npm run build` 통과 (tests 21 pass / 0 fail)
- curl로 formResponse 테스트 전송 → HTTP 200 + "응답이 기록되었습니다" 확인 페이지 수신. 폼 응답 탭에서 테스트 문의 1건 확인 가능

## 💡 리뷰 포인트
- formResponse URL과 entry ID는 폼 자체가 공개인 이상 비밀값이 아니므로 소스에 포함해도 안전합니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [ ] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [ ] 문서(Wiki, API Docs 등)를 업데이트했나요? (기존 가이드 절차와 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)