### PR TITLE
feat: 랜딩 지원 브라우저 표기를 3+로 확장

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -217,7 +217,7 @@
             <span>지원 웹서비스</span>
           </div>
           <div>
-            <strong>3</strong>
+            <strong>3+</strong>
             <span>지원 브라우저</span>
           </div>
           <div>
@@ -495,7 +495,11 @@
           <div class="section-heading">
             <p class="section-kicker">쓰던 브라우저 그대로</p>
             <h2 id="browsers-title">어디서든 같은 LinKHU</h2>
-            <p>Chrome, Firefox, Naver Whale에서 바로 설치할 수 있습니다.</p>
+            <p>
+              Chrome, Firefox, Naver Whale에서 바로 설치할 수 있습니다.
+              Edge, Brave 같은 크로미움 기반 브라우저도 Chrome 웹 스토어를 통해
+              설치할 수 있습니다.
+            </p>
           </div>
 
           <div class="browser-links">


### PR DESCRIPTION
## 📝 요약
> Edge·Brave 등 크로미움 기반 브라우저도 Chrome 웹 스토어로 설치 가능하므로, 랜딩 통계를 3 → 3+로 바꾸고 브라우저 섹션 설명에 근거 한 줄을 추가했습니다.

## ⚙️ 작업 사항
- [x] 히어로 통계 "지원 브라우저" 3 → 3+
- [x] 브라우저 섹션 설명에 크로미움 설치 안내 추가

## 📌 관련 이슈
- Close #95

## 🧪 테스트 결과
- 로컬 서버(localhost:8765)에서 "3+"와 크로미움 안내 문구 렌더 확인

## 💡 리뷰 포인트
- 문구 톤이 마음에 드는지 확인해주세요.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요? (문서/마크업 변경, 로컬 확인)
- [ ] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [ ] 문서(Wiki, API Docs 등)를 업데이트했나요? (해당 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)