### PR TITLE
feat: 경희대 공식 색상 정합 및 디자인 토큰 도입

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@
       name="description"
       content="경희대학교 학생을 위한 웹서비스 바로가기 브라우저 확장 프로그램, LinKHU"
     >
-    <meta name="theme-color" content="#8f1d31">
+    <meta name="theme-color" content="#a40f16">
     <meta property="og:title" content="LinKHU — 경희대 웹서비스를 한곳에">
     <meta
       property="og:description"

--- a/docs/landing.css
+++ b/docs/landing.css
@@ -1,8 +1,9 @@
 :root {
   color-scheme: light;
+  /* primary 3종은 src/theme.css의 :root와 값을 동기 유지한다. GitHub Pages가 docs/만 서빙해 파일을 공유할 수 없다. */
   --color-primary: #a40f16;
   --color-primary-strong: #790b11;
-  --color-primary-soft: #fae8e9;
+  --color-primary-soft: #fdeeef;
   --color-accent: #a87827;
   --color-background: #fbfaf8;
   --color-surface: #ffffff;
@@ -1811,7 +1812,7 @@ kbd {
 
   .feature-card-accent,
   .cta-card {
-    background-color: #8f1d31;
+    background-color: #a40f16;
   }
 
   .mini-list {

--- a/docs/landing.css
+++ b/docs/landing.css
@@ -1,8 +1,8 @@
 :root {
   color-scheme: light;
-  --color-primary: #8f1d31;
-  --color-primary-strong: #741526;
-  --color-primary-soft: #f6e8eb;
+  --color-primary: #a40f16;
+  --color-primary-strong: #790b11;
+  --color-primary-soft: #fae8e9;
   --color-accent: #a87827;
   --color-background: #fbfaf8;
   --color-surface: #ffffff;
@@ -221,12 +221,12 @@ a {
 .button-primary {
   background: var(--color-primary);
   color: #ffffff;
-  box-shadow: 0 10px 28px rgba(143, 29, 49, 0.2);
+  box-shadow: 0 10px 28px rgba(164, 15, 22, 0.2);
 }
 
 .button-primary:hover {
   background: var(--color-primary-strong);
-  box-shadow: 0 14px 32px rgba(143, 29, 49, 0.27);
+  box-shadow: 0 14px 32px rgba(164, 15, 22, 0.27);
 }
 
 .button-secondary {
@@ -262,7 +262,7 @@ a {
   left: -260px;
   width: 620px;
   height: 620px;
-  background: radial-gradient(circle, rgba(143, 29, 49, 0.1), transparent 68%);
+  background: radial-gradient(circle, rgba(164, 15, 22, 0.1), transparent 68%);
 }
 
 .hero-glow-right {
@@ -809,7 +809,7 @@ kbd {
   inset: 46px 28px auto;
   height: 100%;
   border-radius: 18px;
-  background: rgba(143, 29, 49, 0.08);
+  background: rgba(164, 15, 22, 0.08);
   transform: rotate(-3deg);
 }
 

--- a/src/options.css
+++ b/src/options.css
@@ -29,7 +29,7 @@ body {
 }
 
 h1 {
-  color: #9d2235;
+  color: var(--color-primary);
   text-align: center;
   margin: 0 0 4px;
 }
@@ -43,9 +43,9 @@ h1 {
 .shortcut-guide {
   margin-bottom: 18px;
   padding: 14px 16px;
-  border: 1px solid #f1c7cf;
+  border: 1px solid var(--color-primary-border);
   border-radius: 8px;
-  background: #fff7f8;
+  background: var(--color-primary-soft);
   color: #333;
   font-size: 13px;
 }
@@ -53,7 +53,7 @@ h1 {
 .shortcut-guide strong {
   display: block;
   margin-bottom: 6px;
-  color: #9d2235;
+  color: var(--color-primary);
 }
 
 .shortcut-guide p {
@@ -74,7 +74,7 @@ h1 {
   padding: 0;
   border: 0;
   background: transparent;
-  color: #9d2235;
+  color: var(--color-primary);
   cursor: pointer;
   font: inherit;
   font-weight: 600;
@@ -149,8 +149,8 @@ h1 {
 }
 
 .option-search input:focus {
-  border-color: #9d2235;
-  box-shadow: 0 0 0 3px rgba(157, 34, 53, 0.12);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-ring);
 }
 
 .search-empty-message {
@@ -190,7 +190,7 @@ h1 {
 .category-title {
   font-size: 13px;
   font-weight: bold;
-  color: #9d2235;
+  color: var(--color-primary);
   margin: 0 0 10px 5px;
 }
 
@@ -225,8 +225,8 @@ h1 {
 
 .list-item.dragging {
   opacity: 0.5;
-  background: #ffe3e3;
-  border-color: #9d2235;
+  background: var(--color-primary-soft);
+  border-color: var(--color-primary);
 }
 
 .list-item img {
@@ -253,7 +253,7 @@ h1 {
   width: 100%;
   padding: 15px;
   margin-top: 20px;
-  background-color: #9d2235;
+  background-color: var(--color-primary);
   color: white;
   border: none;
   border-radius: 8px;
@@ -264,7 +264,7 @@ h1 {
 }
 
 .save-btn:hover {
-  background-color: #7a1a29;
+  background-color: var(--color-primary-strong);
 }
 
 .options-footer {
@@ -288,7 +288,7 @@ h1 {
 }
 
 .footer-link:hover {
-  color: #9d2235;
+  color: var(--color-primary);
   text-decoration: underline;
 }
 
@@ -317,8 +317,8 @@ h1 {
 
 .feedback-panel textarea:focus {
   outline: none;
-  border-color: #9d2235;
-  box-shadow: 0 0 0 3px rgba(157, 34, 53, 0.12);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-ring);
 }
 
 .feedback-email {
@@ -336,8 +336,8 @@ h1 {
 
 .feedback-email:focus {
   outline: none;
-  border-color: #9d2235;
-  box-shadow: 0 0 0 3px rgba(157, 34, 53, 0.12);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-ring);
 }
 
 .feedback-actions {
@@ -350,7 +350,7 @@ h1 {
   padding: 6px 16px;
   border: none;
   border-radius: 6px;
-  background: #9d2235;
+  background: var(--color-primary);
   color: #ffffff;
   font-family: inherit;
   font-size: 13px;

--- a/src/options.html
+++ b/src/options.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>LinKHU 설정</title>
+    <link rel="stylesheet" href="theme.css" />
     <link rel="stylesheet" href="options.css" />
   </head>
   <body>

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,11 +1,10 @@
 :root {
-  --primary-color: #9d2235;
   --bg-color: #f8f9fa;
   --card-bg: #ffffff;
   --text-main: #333333;
   --border-color: #eeeeee;
   --shadow-sm: 0 4px 6px rgba(0, 0, 0, 0.05);
-  --shadow-hover: 0 6px 12px rgba(157, 34, 53, 0.15);
+  --shadow-hover: 0 6px 12px var(--color-primary-shadow);
   --radius-md: 12px;
 }
 
@@ -32,7 +31,7 @@ header h1 {
   margin: 0;
   font-size: 20px;
   font-weight: 700;
-  color: var(--primary-color);
+  color: var(--color-primary);
 }
 
 .search-bar {
@@ -70,8 +69,8 @@ header h1 {
 }
 
 .search-bar input:focus {
-  border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(157, 34, 53, 0.12);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-ring);
 }
 
 .update-link {
@@ -140,7 +139,7 @@ header h1 {
 .grid-item:hover {
   transform: translateY(-3px);
   box-shadow: var(--shadow-hover);
-  border-color: #ffadad;
+  border-color: var(--color-primary-border);
 }
 
 .grid-item:active {
@@ -174,7 +173,7 @@ header h1 {
 }
 
 .footer-link:hover {
-  color: var(--primary-color);
+  color: var(--color-primary);
   text-decoration: underline;
 }
 
@@ -202,8 +201,8 @@ header h1 {
 
 .feedback-panel textarea:focus {
   outline: none;
-  border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(157, 34, 53, 0.12);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-ring);
 }
 
 .feedback-email {
@@ -221,8 +220,8 @@ header h1 {
 
 .feedback-email:focus {
   outline: none;
-  border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(157, 34, 53, 0.12);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-ring);
 }
 
 .feedback-actions {
@@ -235,7 +234,7 @@ header h1 {
   padding: 5px 14px;
   border: none;
   border-radius: 6px;
-  background: var(--primary-color);
+  background: var(--color-primary);
   color: #ffffff;
   font-family: inherit;
   font-size: 12px;

--- a/src/popup.html
+++ b/src/popup.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LinKHU</title>
+    <link rel="stylesheet" href="theme.css" />
     <link rel="stylesheet" href="popup.css" />
   </head>
   <body>
@@ -23,7 +24,7 @@
               margin: 0;
               font-size: 20px;
               font-weight: 700;
-              color: #9d2235;
+              color: #a40f16;
               line-height: 1;
             "
           >
@@ -51,7 +52,7 @@
             height="20"
             viewBox="0 0 24 24"
             fill="none"
-            stroke="#9d2235"
+            stroke="#a40f16"
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"

--- a/src/popup.html
+++ b/src/popup.html
@@ -24,7 +24,7 @@
               margin: 0;
               font-size: 20px;
               font-weight: 700;
-              color: #a40f16;
+              color: var(--color-primary);
               line-height: 1;
             "
           >
@@ -52,7 +52,7 @@
             height="20"
             viewBox="0 0 24 24"
             fill="none"
-            stroke="#a40f16"
+            style="stroke: var(--color-primary)"
             stroke-width="2"
             stroke-linecap="round"
             stroke-linejoin="round"

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,23 @@
+/*
+ * LinKHU 디자인 토큰
+ *
+ * 브랜드 색상은 경희대학교 공식 Kyung Hee Red를 사용한다.
+ * PANTONE 201C / RGB(164, 15, 22) / #a40f16
+ *
+ * 파생값은 모두 같은 색상(hue 357°) 계열이며, 용도별 시맨틱 이름으로 노출한다.
+ * 새 화면에서 브랜드 레드가 필요하면 hex를 직접 쓰지 말고 이 토큰을 참조한다.
+ */
+:root {
+  /* 로고, 강조 텍스트, 기본 버튼 배경 */
+  --color-primary: #a40f16;
+  /* 기본 버튼 hover 등 눌린 상태 */
+  --color-primary-strong: #790b11;
+  /* 안내 박스, 드래그 중 항목처럼 옅게 깔리는 배경 */
+  --color-primary-soft: #fdeeef;
+  /* 옅은 배경 영역과 카드 hover 테두리 */
+  --color-primary-border: #f4bfc3;
+  /* 입력 요소 focus ring */
+  --color-primary-ring: rgba(164, 15, 22, 0.12);
+  /* 카드 hover 그림자 */
+  --color-primary-shadow: rgba(164, 15, 22, 0.15);
+}

--- a/src/theme.css
+++ b/src/theme.css
@@ -8,6 +8,7 @@
  * 새 화면에서 브랜드 레드가 필요하면 hex를 직접 쓰지 말고 이 토큰을 참조한다.
  */
 :root {
+  /* primary 3종은 docs/landing.css의 :root와 값을 동기 유지한다. GitHub Pages가 docs/만 서빙해 파일을 공유할 수 없다. */
   /* 로고, 강조 텍스트, 기본 버튼 배경 */
   --color-primary: #a40f16;
   /* 기본 버튼 hover 등 눌린 상태 */


### PR DESCRIPTION
## 📝 요약
> 이번 PR에서 작업한 핵심 내용을 간단히 적어주세요.

브랜드 색상을 경희대학교 공식 **Kyung Hee Red**(PANTONE 201C, RGB(164, 15, 22) = `#a40f16`)로 통일하고, 확장 프로그램에 시맨틱 색상 토큰(`src/theme.css`)을 도입했습니다.

기존에는 확장 프로그램이 `#9d2235`, 랜딩이 `#8f1d31`로 서로 다른 값을 쓰고 있었고 둘 다 공식 색상이 아니었습니다. 이제 두 곳 모두 같은 공식 색상을 사용하며, 확장 프로그램 쪽은 앞으로 색을 바꿀 때 `src/theme.css` 한 곳만 고치면 됩니다.

**레이아웃, 크기, 컴포넌트 구조는 전혀 건드리지 않았습니다. 색 값 치환만 수행했습니다.**

## ⚙️ 작업 사항
- [x] `src/theme.css` 신설 — 시맨틱 색상 토큰 정의 후 `popup.html` / `options.html`에서 로드
- [x] `src/popup.css` 브랜드 레드 계열 하드코딩 값을 토큰 참조로 치환
- [x] `src/options.css` 브랜드 레드 계열 하드코딩 값을 토큰 참조로 치환
- [x] `src/popup.html` 인라인 스타일과 인라인 SVG를 `var(--color-primary)` 참조로 전환
- [x] `docs/landing.css` 라이트 테마 브랜드 색상을 공식 색상으로 교체
- [x] (리뷰 반영) 랜딩 다크 모드에 남아 있던 구 브랜드색 `#8f1d31` 제거
- [x] (리뷰 반영) 확장/랜딩 간 `--color-primary-soft` 값 불일치 해소 및 동기 유지 주석 추가

### 도입한 토큰 (`src/theme.css`)

| 토큰 | 값 | 용도 |
| --- | --- | --- |
| `--color-primary` | `#a40f16` | 로고, 강조 텍스트, 기본 버튼 배경 |
| `--color-primary-strong` | `#790b11` | 기본 버튼 hover 등 눌린 상태 |
| `--color-primary-soft` | `#fdeeef` | 안내 박스, 드래그 중 항목 배경 |
| `--color-primary-border` | `#f4bfc3` | 옅은 배경 영역과 카드 hover 테두리 |
| `--color-primary-ring` | `rgba(164, 15, 22, 0.12)` | 입력 요소 focus ring |
| `--color-primary-shadow` | `rgba(164, 15, 22, 0.15)` | 카드 hover 그림자 |

파생값은 모두 `#a40f16`과 같은 색상(hue 357°) 계열입니다.

`--color-primary` / `-strong` / `-soft` 3종은 `docs/landing.css`의 `:root`와 값이 같아야 합니다. GitHub Pages가 `docs/`만 서빙하기 때문에 파일을 공유할 수 없어, 두 파일의 `:root`에 서로를 가리키는 동기 유지 주석을 한 줄씩 남겼습니다.

### 치환 매핑

| 기존 값 | 대체 | 위치 |
| --- | --- | --- |
| `#9d2235` | `var(--color-primary)` | `popup.css`, `options.css`, `popup.html` |
| `#7a1a29` | `var(--color-primary-strong)` | `options.css` |
| `rgba(157, 34, 53, 0.12)` | `var(--color-primary-ring)` | `popup.css`, `options.css` (6곳) |
| `rgba(157, 34, 53, 0.15)` | `var(--color-primary-shadow)` | `popup.css` |
| `#f1c7cf`, `#ffadad` | `var(--color-primary-border)` | `options.css`, `popup.css` |
| `#fff7f8`, `#ffe3e3` | `var(--color-primary-soft)` | `options.css` |

- `popup.css`의 기존 `--primary-color` 선언은 제거하고 `--color-primary`로 직접 참조하도록 바꿨습니다. 이름이 둘로 나뉘는 것을 피하기 위해 별칭은 두지 않았습니다.
- `popup.html`의 톱니바퀴 아이콘은 `stroke="#a40f16"` 표현 속성으로는 CSS 변수를 쓸 수 없어, `style="stroke: var(--color-primary)"`로 옮겨 CSS 컨텍스트를 확보했습니다. `stroke-width`, `fill` 등 나머지 표현 속성은 그대로 뒀습니다.
- 회색 계열(`#333`, `#777`, `#ddd` 등)과 기능색은 그대로 뒀습니다. 특히 `popup.css`의 `.update-link` 색상 `#ff6b6b`은 브랜드 레드가 아니라 "새 버전 있음"을 알리는 기능색으로 판단해 유지했습니다. (리뷰 포인트 참고)

## 📌 관련 이슈
- Close #99

## 🧪 테스트 결과
> 작업한 내용이 의도대로 동작하는지 확인한 결과(스크린샷, 로그 등)를 첨부해주세요.

아래는 리뷰 반영 커밋(`92e0d92`)까지 적용한 상태에서 재실행한 결과입니다.

### `npm test`

```
ℹ tests 23
ℹ suites 0
ℹ pass 23
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 67.212708
```

23개 전부 통과했습니다.

### `npm run build`

```
Data validation passed.

> validate:landing-data
> node scripts/generate-landing-data.js --check

Landing service data is up to date.
Landing icons are up to date.

> package
> node scripts/package-extension.js

Packaged 130 files into dist/linkhu-v2.4.0.zip.
```

통과했습니다. 패키징 스크립트가 `src/` 하위를 자동으로 수집하므로 `src/theme.css`도 ZIP에 포함되는 것을 확인했습니다.

```
$ unzip -l dist/linkhu-v2.4.0.zip | grep -E 'theme.css|popup.css|options.css'
     6104  01-01-1980 00:00   options.css
     4908  01-01-1980 00:00   popup.css
      915  01-01-1980 00:00   theme.css
```

### 정적 검증

`src/*.css`에서 참조하는 토큰과 `src/theme.css`에 정의된 토큰이 정확히 일치합니다 (미정의 변수 0개).

```
$ grep -ohE 'var\(--color-[a-z-]+\)' src/*.css | sort -u
var(--color-primary)
var(--color-primary-border)
var(--color-primary-ring)
var(--color-primary-shadow)
var(--color-primary-soft)
var(--color-primary-strong)
```

구 브랜드 값 잔여 검색 결과, 의도적으로 남긴 1건 외에는 모두 정리되었습니다.

```
$ grep -rn -iE '#(9d2235|7a1a29|8f1d31|741526|f6e8eb|f1c7cf|fff7f8|ffe3e3|ffadad|fae8e9)|157, 34, 53|143, 29, 49' src/ docs/*.css docs/*.html docs/*.js
docs/landing.css:1227:  background: #fff7f8;   # .button-light:hover, 거의 흰색에 가까운 틴트라 유지
```

`src/` 안에 남은 `#a40f16` 리터럴은 `src/theme.css`의 토큰 정의와 주석뿐입니다. 나머지 위치는 전부 토큰을 참조합니다.

```
$ grep -rn 'a40f16' src/
src/theme.css:5: * PANTONE 201C / RGB(164, 15, 22) / #a40f16
src/theme.css:13:  --color-primary: #a40f16;
```

`git diff --check` 통과했습니다.

### 브라우저 수동 검증

실제 Chromium에서 `src/popup.html`, `src/options.html`, `docs/index.html`을 열어 확인했습니다.

**`popup.html`** — theme.css가 정상 로드되어 모든 토큰이 의도한 값으로 해석됩니다. 표현 속성에서 `style`로 옮긴 SVG 아이콘도 브랜드 레드로 렌더링되고, `stroke-width`와 `fill`은 그대로 유지됩니다.

```json
{
  "h1Color": "rgb(164, 15, 22)",
  "svgStroke": "rgb(164, 15, 22)",
  "svgHasStrokeAttr": false,
  "strokeWidth": "2px",
  "fill": "none",
  "softToken": "#fdeeef"
}
```

**`options.html`** — 단축키 안내 박스(기본 `hidden`)와 `.list-item.dragging` 상태를 강제로 노출시켜 `--color-primary-soft` / `--color-primary-border` 적용을 함께 확인했습니다. 제목, 카테고리 라벨, 안내 박스, 드래그 중 항목, 저장 버튼 모두 새 브랜드 색으로 렌더링되고 레이아웃 변화는 없었습니다.

**`docs/index.html`** — `Emulation.setEmulatedMedia`로 라이트/다크를 각각 강제해 확인했습니다. 라이트 테마는 확장 프로그램과 `--color-primary-soft`까지 값이 일치하고, 다크 테마는 팔레트(`--color-primary: #e57a8e`, `--color-primary-soft: #40242b`)를 그대로 유지한 채 `.feature-card-accent` / `.cta-card`의 구 브랜드색만 새 값으로 바뀐 것을 확인했습니다.

```json
// prefers-color-scheme: light
{ "scheme": "light", "primary": "#a40f16", "soft": "#fdeeef",
  "accentBg": "rgb(164, 15, 22)", "ctaBg": "rgb(164, 15, 22)" }

// prefers-color-scheme: dark
{ "scheme": "dark",  "primary": "#e57a8e", "soft": "#40242b",
  "accentBg": "rgb(164, 15, 22)", "ctaBg": "rgb(164, 15, 22)" }
```

확장 프로그램을 실제로 로드해서 하는 검증(팝업 그리드 클릭, 설정 페이지 드래그 앤 드롭)은 하지 않았습니다. 이번 변경이 CSS 색 값에만 국한되어 동작 로직에 영향이 없기 때문입니다.

## 💡 리뷰 포인트

### 리뷰 반영 완료 (`92e0d92`)
- 랜딩 다크 모드의 `.feature-card-accent` / `.cta-card` 배경에 남아 있던 `#8f1d31`을 `#a40f16`으로 교체했습니다. 다크 팔레트 자체(`--color-primary: #e57a8e` 등)는 의도된 밝은 톤이라 그대로 뒀고, 구 브랜드색 잔존만 제거했습니다.
- `--color-primary-soft`가 확장(`#fdeeef`)과 랜딩(`#fae8e9`)에서 어긋나 있던 것을 `#fdeeef`로 통일하고, 두 파일의 `:root`에 동기 유지 주석을 남겼습니다.
- `popup.html`에 하드코딩돼 있던 `#a40f16`을 토큰 참조로 바꿨습니다.

### 남은 판단 지점
- 지시 범위를 살짝 넘은 판단이 세 가지 있습니다. 모두 "구 primary와 같은 색을 다른 형태로 쓰고 있던 값"이라 함께 정리하는 것이 브랜드 정합이라는 목적에 맞다고 봤는데, 범위를 좁히는 편이 좋다면 알려주세요.
  1. `docs/landing.css`의 `rgba(143, 29, 49, *)` 4곳 → `rgba(164, 15, 22, *)`. 그대로 뒀다면 새 primary와 그림자/글로우 색이 어긋납니다.
  2. `docs/landing.css`의 `--color-primary-soft` 값 조정. 명도는 기존 톤을 유지했습니다.
  3. `docs/index.html`의 `theme-color` 메타 태그 `#8f1d31` → `#a40f16`. 브라우저 UI 색상이라 랜딩 헤더 색과 어긋나면 눈에 띕니다.
- `#f1c7cf`(설정 안내 박스 테두리)와 `#ffadad`(팝업 카드 hover 테두리)를 `--color-primary-border` 하나로 통합했습니다. 두 값의 명도가 원래 비슷했고(L≈0.86 / 0.84) 역할도 "브랜드 계열 옅은 테두리"로 같아서 토큰화하며 합쳤습니다. 두 자리를 구분해서 유지하는 게 낫다면 토큰을 나누겠습니다.
- `.update-link`의 `#ff6b6b`은 브랜드색이 아닌 기능색(업데이트 알림)으로 보고 유지했습니다. 새 primary와 나란히 놓았을 때 톤이 튀어 보인다면 별도 이슈로 조정하는 게 좋을 것 같습니다.
- `docs/landing.css:1227`의 `.button-light:hover` 배경 `#fff7f8`은 거의 흰색에 가까운 틴트(hue 352°)라 유지했습니다. 랜딩에는 토큰화되지 않은 일회성 색이 이 외에도 몇 개 있어, 랜딩 쪽 토큰 정리는 별도 이슈로 다루는 게 맞아 보입니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음, `npm run build`의 `validate:data` 통과 결과 포함)
- [ ] 문서(Wiki, API Docs 등)를 업데이트했나요? — 문서 변경 사항 없음

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->
