### PR TITLE
docs: Chrome 배포 토큰 만료 대응 문서화

### DIFF
--- a/docs/chrome-web-store-automation.md
+++ b/docs/chrome-web-store-automation.md
@@ -43,7 +43,75 @@ Chrome Web Store extension ID는 워크플로우에 `ihidkmjkpfphgljieecfcikljao
 - Store Listing, Privacy, Distribution 정보 변경이 필요한지 확인한다.
 - 권한 변경이 있는 경우 심사용 안내가 필요한지 확인한다.
 
+## 토큰 만료 대응
+
+### 증상
+
+`Publish to Chrome Web Store` 단계에서 다음 오류가 나면 refresh token이 만료된 것이다.
+
+```text
+Chrome access token request failed (400): {"error":"invalid_grant","error_description":"Token has been expired or revoked."}
+```
+
+- 입력값 오류는 증상이 다르다. `confirm_publish`가 `publish-chrome`이 아니면 그 앞 `Verify release input` 단계에서 `confirm_publish must be publish-chrome.`로 걸린다.
+- 즉 **어느 단계에서 멈췄는지를 먼저 본다.** `Verify release input`이면 입력값 문제이고, `Publish to Chrome Web Store`면 토큰 문제다.
+
+### 원인
+
+Google Cloud OAuth 동의 화면의 게시 상태가 **테스트(Testing)**이면 발급된 refresh token이 **7일 후 만료**된다. 프로덕션 상태면 만료되지 않는다.
+
+### 근본 해결 (권장)
+
+Google Cloud Console에서 **OAuth 동의 화면을 '프로덕션'으로 전환한다.**
+
+- 본인 계정만 사용하는 앱이므로 Google 심사 대상이 아니다.
+- 전환하면 refresh token이 만료되지 않으므로 **아래 재발급 절차 자체가 필요 없어진다.**
+
+### 재발급 절차 (프로덕션 전환 전까지의 임시 대응)
+
+1. OAuth 클라이언트가 **웹 애플리케이션** 유형인지 확인한다. 승인된 리디렉션 URI에 `https://developers.google.com/oauthplayground`가 있어야 한다.
+2. 동의 URL을 만든다. `https://accounts.google.com/o/oauth2/auth`에 다음 쿼리를 붙인다.
+
+   | 파라미터 | 값 |
+   | --- | --- |
+   | `response_type` | `code` |
+   | `client_id` | `{CHROME_CLIENT_ID}` |
+   | `redirect_uri` | `https://developers.google.com/oauthplayground` |
+   | `scope` | `https://www.googleapis.com/auth/chromewebstore` |
+   | `access_type` | `offline` |
+   | `prompt` | `consent` |
+
+   **`access_type=offline`과 `prompt=consent`가 없으면 refresh token이 발급되지 않는다.**
+
+3. 브라우저에서 그 URL을 열어 동의한다. 리디렉션된 주소창에 `code` 파라미터가 온다.
+4. 받은 코드를 토큰으로 교환한다.
+
+   ```bash
+   curl -s -X POST https://oauth2.googleapis.com/token \
+     -d code={AUTH_CODE} \
+     -d client_id={CHROME_CLIENT_ID} \
+     -d client_secret={CHROME_CLIENT_SECRET} \
+     -d redirect_uri=https://developers.google.com/oauthplayground \
+     -d grant_type=authorization_code
+   ```
+
+5. 응답의 `refresh_token`을 secret에 저장한다.
+
+   ```bash
+   gh secret set CHROME_REFRESH_TOKEN
+   ```
+
+6. 워크플로를 재실행한다.
+
+   ```bash
+   gh workflow run publish-chrome.yml --ref main \
+     -f version={version} -f confirm_publish=publish-chrome
+   ```
+
+**자리표시자(`{...}`)에 실제 값을 적어 커밋하지 않는다** (MUST). 이 저장소는 공개다.
+
 ## 참고 문서
 
 - [Use the Chrome Web Store API](https://developer.chrome.com/docs/webstore/using_webstore_api)
 - [Chrome Web Store API reference](https://developer.chrome.com/docs/webstore/api/reference/rest)
+- [OAuth 2.0 for Web Server Applications](https://developers.google.com/identity/protocols/oauth2/web-server)

--- a/docs/chrome-web-store-automation.md
+++ b/docs/chrome-web-store-automation.md
@@ -47,7 +47,7 @@ Chrome Web Store extension ID는 워크플로우에 `ihidkmjkpfphgljieecfcikljao
 
 ### 증상
 
-`Publish to Chrome Web Store` 단계에서 다음 오류가 나면 refresh token이 만료된 것이다.
+`Publish to Chrome Web Store` 단계에서 다음 오류가 나면 refresh token이 만료되었거나 폐기된 것이다.
 
 ```text
 Chrome access token request failed (400): {"error":"invalid_grant","error_description":"Token has been expired or revoked."}
@@ -60,14 +60,25 @@ Chrome access token request failed (400): {"error":"invalid_grant","error_descri
 
 Google Cloud OAuth 동의 화면의 게시 상태가 **테스트(Testing)**이면 발급된 refresh token이 **7일 후 만료**된다. 프로덕션 상태면 만료되지 않는다.
 
-### 근본 해결 (권장)
+### 현재 상태 — 프로덕션으로 전환 완료 (2026-07-30)
 
-Google Cloud Console에서 **OAuth 동의 화면을 '프로덕션'으로 전환한다.**
+**OAuth 동의 화면은 프로덕션 상태다.** 따라서 refresh token은 더 이상 7일마다 만료되지 않는다.
 
 - 본인 계정만 사용하는 앱이므로 Google 심사 대상이 아니다.
-- 전환하면 refresh token이 만료되지 않으므로 **아래 재발급 절차 자체가 필요 없어진다.**
+- 만료 때문에 토큰을 주기적으로 재발급할 필요는 없어졌다. 아래 절차는 예외 상황용이다.
 
-### 재발급 절차 (프로덕션 전환 전까지의 임시 대응)
+### ⚠️ 게시 상태는 경고 표시로 판별할 수 없다
+
+동의 화면에서 **"확인되지 않은 앱"(unverified app) 경고가 뜬다고 테스트 상태인 것이 아니다.**
+
+`https://www.googleapis.com/auth/chromewebstore`는 Google이 **민감한 스코프**로 분류한다. 프로덕션으로 전환했더라도 Google 검증(verification)을 받지 않았으면 이 경고가 계속 나온다.
+
+- **게시 상태 판별은 Google Cloud Console의 OAuth 동의 화면 → 게시 상태 항목으로만 한다** (MUST).
+- 개인용 앱은 검증을 받지 않아도 된다. 경고 화면에서 **고급 → 안전하지 않은 페이지로 이동**으로 진행하면 되고, 이 경고는 무해하다.
+
+### 토큰을 다시 발급해야 할 때
+
+프로덕션 전환으로 만료는 해소되었지만, **토큰이 폐기되었거나 OAuth 클라이언트를 교체하는 경우**에는 여전히 재발급이 필요하다.
 
 1. OAuth 클라이언트가 **웹 애플리케이션** 유형인지 확인한다. 승인된 리디렉션 URI에 `https://developers.google.com/oauthplayground`가 있어야 한다.
 2. 동의 URL을 만든다. `https://accounts.google.com/o/oauth2/auth`에 다음 쿼리를 붙인다.
@@ -109,6 +120,26 @@ Google Cloud Console에서 **OAuth 동의 화면을 '프로덕션'으로 전환�
    ```
 
 **자리표시자(`{...}`)에 실제 값을 적어 커밋하지 않는다** (MUST). 이 저장소는 공개다.
+
+### 스코프는 `chromewebstore` 하나만 발급한다
+
+발급된 토큰의 스코프는 `https://www.googleapis.com/auth/chromewebstore` 하나여야 한다. 배포에 필요한 권한이 그것뿐이다.
+
+**`gcloud auth application-default login`을 이 용도로 쓰지 않는다** (MUST). 이 명령은 `cloud-platform` 스코프를 강제하므로 토큰 권한이 필요 이상으로 넓어진다. 위 동의 URL 방식으로 `scope`를 직접 지정해 발급한다.
+
+### 실행 기록
+
+**v2.5.0 (2026-07-30)** — 두 단계에서 연속으로 막혔다.
+
+| 순서 | 단계 | 결과 |
+| --- | --- | --- |
+| 1 | `Verify release input` | 실패 — 입력값 오타 |
+| 2 | `Publish to Chrome Web Store` | 실패 — refresh token 만료 (`invalid_grant`) |
+| 3 | 토큰 재발급 후 재실행 | **성공 — `PENDING_REVIEW`** |
+
+같은 배포에서 서로 다른 두 오류를 순서대로 겪었다. 위 [증상](#증상) 절의 단계 구분이 여기서 나왔다.
+
+재발급한 토큰의 스코프는 `chromewebstore` 하나뿐이었다. 같은 날 OAuth 동의 화면을 프로덕션으로 전환해 만료 문제를 없앴다.
 
 ## 참고 문서
 

--- a/docs/store-release-checklist.md
+++ b/docs/store-release-checklist.md
@@ -34,6 +34,8 @@ LinKHU 스토어 배포는 GitHub Release에 첨부된 ZIP 파일을 기준으�
 
 기본 배포 경로는 [Chrome Web Store Automation](./chrome-web-store-automation.md)의 `Publish Chrome Web Store` 워크플로우다. 워크플로우 실행 후 대시보드에서 심사 제출 상태를 확인하며, 아래 수동 절차는 자동 배포 실패 또는 긴급 fallback이 필요할 때 사용한다.
 
+- **워크플로우를 돌리기 전에 `CHROME_REFRESH_TOKEN` 만료 여부를 먼저 확인한다.** OAuth 동의 화면이 테스트 게시 상태면 토큰이 7일 만에 만료되어 `Publish to Chrome Web Store` 단계에서 `invalid_grant`로 멈춘다. 증상·근본 해결·재발급 절차는 [토큰 만료 대응](./chrome-web-store-automation.md#토큰-만료-대응)에 있다.
+
 - [Chrome Developer Dashboard](https://chrome.google.com/webstore/devconsole)에 접속한다.
 - LinKHU 아이템을 선택한다.
 - 새 패키지로 `linkhu-v{version}.zip`을 업로드한다.

--- a/docs/store-release-checklist.md
+++ b/docs/store-release-checklist.md
@@ -34,7 +34,7 @@ LinKHU 스토어 배포는 GitHub Release에 첨부된 ZIP 파일을 기준으�
 
 기본 배포 경로는 [Chrome Web Store Automation](./chrome-web-store-automation.md)의 `Publish Chrome Web Store` 워크플로우다. 워크플로우 실행 후 대시보드에서 심사 제출 상태를 확인하며, 아래 수동 절차는 자동 배포 실패 또는 긴급 fallback이 필요할 때 사용한다.
 
-- **워크플로우를 돌리기 전에 `CHROME_REFRESH_TOKEN` 만료 여부를 먼저 확인한다.** OAuth 동의 화면이 테스트 게시 상태면 토큰이 7일 만에 만료되어 `Publish to Chrome Web Store` 단계에서 `invalid_grant`로 멈춘다. 증상·근본 해결·재발급 절차는 [토큰 만료 대응](./chrome-web-store-automation.md#토큰-만료-대응)에 있다.
+- **워크플로우가 실패하면 어느 단계에서 멈췄는지 먼저 본다.** `Verify release input`이면 입력값 문제, `Publish to Chrome Web Store`에서 `invalid_grant`면 토큰 문제다. OAuth 동의 화면은 프로덕션으로 전환되어 토큰이 주기적으로 만료되지는 않지만, 폐기되거나 클라이언트를 교체하면 재발급이 필요하다. 절차는 [토큰 만료 대응](./chrome-web-store-automation.md#토큰-만료-대응)에 있다.
 
 - [Chrome Developer Dashboard](https://chrome.google.com/webstore/devconsole)에 접속한다.
 - LinKHU 아이템을 선택한다.


### PR DESCRIPTION
## 📝 요약

v2.5.0 릴리스에서 `Publish Chrome Web Store` 워크플로가 `invalid_grant`로 실패했습니다. `CHROME_REFRESH_TOKEN`을 7월 18일에 갱신했는데 **12일 만에 만료**됐습니다.

문서에 토큰 만료 얘기가 전혀 없어 **매 릴리스마다 같은 자리에서 막히고** 그때마다 원인을 다시 찾아야 했습니다. `docs/chrome-web-store-automation.md`에 `토큰 만료 대응` 절을 추가했습니다.

## ⚙️ 작업 사항

- [x] 증상 — 오류 메시지 원문과 입력값 오류와의 구분
- [x] 원인 — OAuth 동의 화면 테스트 상태 → 7일 만료
- [x] 현재 상태 — 프로덕션 전환 완료(2026-07-30) 사실 기록
- [x] 게시 상태를 경고 표시로 판별할 수 없다는 정정
- [x] 재발급 절차 — 예외 상황용, `curl` 예시 포함
- [x] 스코프는 `chromewebstore` 하나만, `gcloud application-default login` 금지
- [x] v2.5.0 실행 기록
- [x] 재실행 명령
- [x] `docs/store-release-checklist.md` Chrome 절에 사전 확인 항목 + 링크

## 📌 관련 이슈

- Close #128

## 🧪 테스트 결과

### 문서 내용을 워크플로·스크립트와 대조했습니다

추측으로 적지 않고 실제 코드에서 확인했습니다.

| 문서에 적은 것 | 근거 |
| --- | --- |
| `Publish to Chrome Web Store` 단계에서 실패 | `.github/workflows/publish-chrome.yml:54` |
| `Verify release input` 단계가 앞에 있음 | 같은 파일 `:34` |
| `confirm_publish must be publish-chrome.` | 같은 파일 `:45` |
| `Chrome access token request failed (400): …` 형식 | `scripts/publish-chrome.js:61`의 라벨 + `:41`의 `${label} failed (${status}): ${message}` |
| 토큰 엔드포인트 `https://oauth2.googleapis.com/token` | `scripts/publish-chrome.js:62` |

**두 오류가 다른 단계에서 나온다는 점**을 문서에 적은 이유입니다. `Verify release input`은 입력값·태그·릴리스 노트를 검사하고, 토큰은 그 다음 단계에서 처음 쓰입니다. 어느 단계에서 멈췄는지가 곧 진단입니다.

### 시크릿 유출 검사 — 0건

Google 자격증명 패턴을 전수 검사했습니다.

```
$ grep -nE '[0-9]{10,}-[a-z0-9]{20,}\.apps\.googleusercontent\.com|GOCSPX-|1//[A-Za-z0-9_-]{20,}|ya29\.' docs/*.md
  (결과 없음)
```

문서에 쓰인 자리표시자는 셋뿐입니다.

```
{CHROME_CLIENT_ID}  {CHROME_CLIENT_SECRET}  {AUTH_CODE}
```

`gh secret set CHROME_REFRESH_TOKEN`은 **값을 인자로 받지 않는 형태**로 적었습니다. 대화형 입력이라 셸 히스토리에 토큰이 남지 않습니다.

스크린샷은 넣지 않았습니다.

### 링크 유효성

```
docs/store-release-checklist.md → chrome-web-store-automation.md   OK
docs/store-release-checklist.md → firefox-addons-automation.md     OK
docs/store-release-checklist.md → screenshot-guide.md              OK
docs/store-release-checklist.md → store-listing.md                 OK
docs/store-release-checklist.md → whale-store-automation.md        OK
```

앵커도 확인했습니다 — `#토큰-만료-대응`이 가리키는 `## 토큰 만료 대응` 제목이 실재합니다.

참고 문서에 [OAuth 2.0 for Web Server Applications](https://developers.google.com/identity/protocols/oauth2/web-server)를 추가했습니다.

### 회귀

```
ℹ tests 50   ℹ pass 50   ℹ fail 0
Dark icons are up to date. (117 icons)
Landing service data is up to date.
Landing icons are up to date.
Packaged 250 files into dist/linkhu-v2.5.0.zip.
```

## 💡 리뷰 포인트

**1. 프로덕션 전환은 완료된 사실로 기록했습니다**

초안은 `근본 해결 (권장)`에서 "전환한다"고 앞으로 할 일처럼 적었습니다. 2026-07-30에 실제로 전환되었으므로 **`현재 상태 — 프로덕션으로 전환 완료`**로 바꿨습니다.

재발급 절차는 지우지 않고 제목만 `토큰을 다시 발급해야 할 때`로 바꿨습니다. 만료는 해소됐지만 **토큰 폐기나 클라이언트 교체 때는 여전히 필요**합니다.

**2. 잘못된 안내를 정정해 문서에 남겼습니다**

작업 중 "동의 화면에 확인되지 않은 앱 경고가 뜨면 테스트 상태"라고 안내했는데 **틀렸습니다.** `chromewebstore`는 Google이 민감한 스코프로 분류하므로, 프로덕션으로 전환해도 검증을 받지 않으면 같은 경고가 계속 나옵니다. 실제로 프로덕션 상태에서 그 경고를 보고 혼란이 있었습니다.

같은 오판이 반복되지 않도록 별도 절로 남겼습니다 — 판별은 **Console의 게시 상태 항목으로만** 하고, 개인용 앱은 `고급 → 안전하지 않은 페이지로 이동`으로 진행하면 되며 경고는 무해합니다.

**3. `gcloud application-default login`을 금지했습니다**

이 명령은 `cloud-platform` 스코프를 강제해 **토큰 권한이 필요 이상으로 넓어집니다.** 배포에 필요한 것은 `chromewebstore` 하나뿐이고, v2.5.0에서 재발급한 토큰도 그 하나였습니다. 동의 URL에 `scope`를 직접 지정하는 방식을 쓰도록 적었습니다.

**4. v2.5.0 배포는 성공했습니다**

실행 기록을 표로 남겼습니다 — 입력값 오타로 `Verify release input` 실패 → 토큰 만료로 `Publish` 실패 → 재발급 후 **`PENDING_REVIEW` 성공**. 증상 절의 단계 구분이 이 경험에서 나왔다는 연결도 적었습니다.

## ✅ 체크리스트

- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요? — 워크플로·스크립트 대조, 링크·앵커·시크릿 검사
- [x] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? — 변경 없음
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요? — 이 PR이 문서 갱신입니다

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->
