### PR TITLE
chore: GitHub Actions 액션을 Node 24 대응 버전으로 갱신

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,16 +27,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload landing page
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/publish-firefox.yml
+++ b/.github/workflows/publish-firefox.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm run build
 
       - name: Upload extension package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linkhu-extension
           path: dist/*.zip


### PR DESCRIPTION
## 📝 요약

워크플로 로그의 Node.js 20 지원 종료 경고에 대응해 **저장소의 node20 런타임 액션을 전부** 갱신했습니다.

지금은 GitHub이 Node 24로 자동 대체해 돌아가지만, **그 대체가 끊기면 워크플로가 일제히 실패합니다.**

**결과: 저장소 전체에서 node20 런타임 액션 0개, CI 로그의 Node 20 경고 완전 소멸.**

## ⚙️ 작업 사항

- [x] 모든 액션의 최신 버전과 **`runs.using`(런타임)** 을 조회로 확인
- [x] node20 액션 5개 갱신 (checkout, setup-node, upload-artifact, configure-pages, deploy-pages)
- [x] composite 액션의 **중첩 의존성**까지 확인해 갱신 (upload-pages-artifact)
- [x] 입력·출력 계약 유지 확인
- [x] 저장소 버전 통일 (checkout 전부 v7)
- [x] YAML 정적 검증 + 모든 `uses` 태그 해석 확인

## 📌 관련 이슈

- Close #130

## 🧪 테스트 결과

### ⚠️ 범위가 넓어진 경위

처음에는 경고 메시지에 이름이 뜬 **checkout·setup-node 둘만** 대상이었습니다. 그 둘을 v7로 올리고 CI를 돌렸더니 **경고가 사라지지 않고 이름만 바뀌어** 남았습니다.

```
1차 수정 전:  ...target Node.js 20...: actions/checkout@v4, actions/setup-node@v4
1차 수정 후:  ...target Node.js 20...: actions/upload-artifact@v4
```

`upload-artifact`는 `validation.yml`에서만 쓰기 때문에, `release`·`publish-*` 로그에서 딴 경고에는 처음부터 이름이 없었습니다. 그래서 조사 단계에서 누락됐습니다.

이슈 #130의 목적이 **Node 20 지원 종료 대응**이므로 node20 액션 전부로 범위를 넓혔습니다.

### 🔑 최신 버전으로 올리면 된다는 가정이 틀린 곳이 두 군데

**버전 번호가 아니라 `action.yml`의 `runs.using`을 봐야** 합니다.

| 액션 | v4 | v5 | v6 | v7 |
| --- | --- | --- | --- | --- |
| `upload-artifact` | node20 | **node20** ← 함정 | node24 | node24 |
| `configure-pages` | node20 | **node20** ← 함정 | node24 | — |
| `checkout` | node20 | node24 | node24 | node24 |
| `setup-node` | node20 | node24 | node24 | node24 |
| `deploy-pages` | node20 | node24 | — | — |

`upload-artifact`를 v5로 올렸다면 **경고가 그대로 남았을 것**입니다. `configure-pages`도 마찬가지입니다.

### 🔑 composite 액션은 중첩 의존성까지 봐야 합니다

`actions/upload-pages-artifact`는 `runs.using: composite`라 **자체 Node 런타임이 없습니다.** 그래서 런타임만 보면 문제없어 보입니다.

그런데 내부에서 다른 액션을 고정 SHA로 씁니다.

```
upload-pages-artifact@v4  →  내부: actions/upload-artifact@ea165f8 (v4.6.2)  = node20 ❌
upload-pages-artifact@v5  →  내부: actions/upload-artifact@bbbca2d (v7.0.0)  = node24 ✅
```

**`runs.using`만 봐서는 드러나지 않는 경로**라 v5로 올렸습니다.

### 변경 내역

| 워크플로 | 액션 | 이전 | 이후 | 이유 |
| --- | --- | --- | --- | --- |
| validation, release, publish-chrome, publish-firefox | `checkout` | v4 | **v7** | v4 = node20 |
| validation, release, publish-chrome, publish-firefox | `setup-node` | v4 | **v7** | v4 = node20 |
| validation | `upload-artifact` | v4 | **v7** | v4·v5 = node20 |
| pages | `configure-pages` | v5 | **v6** | v4·v5 = node20 |
| pages | `deploy-pages` | v4 | **v5** | v4 = node20 |
| pages | `upload-pages-artifact` | v4 | **v5** | 중첩 upload-artifact가 node20 |
| pages | `checkout` | v6 | **v7** | 런타임은 이미 node24, **버전 통일** 목적 |

`pages.yml`의 `checkout`만 기능상 필요가 없는 변경입니다. 같은 파일의 다른 액션 셋을 이미 손대는 김에, 저장소 안에서 checkout이 v6·v7로 갈리는 것을 막으려고 맞췄습니다.

### (4) 최종 감사 — node20 런타임 0개

```
액션                             버전   runs.using   판정
actions/checkout                 v7     node24       OK
actions/configure-pages          v6     node24       OK
actions/deploy-pages             v5     node24       OK
actions/setup-node               v7     node24       OK
actions/upload-artifact          v7     node24       OK
actions/upload-pages-artifact    v5     composite    OK (중첩 upload-artifact=node24)

node20 런타임 액션: 0개
```

### 입력·출력 계약 유지 확인

| 액션 | 쓰는 것 | 결과 |
| --- | --- | --- |
| `checkout` | `fetch-depth` | 입력 21개 v4·v7 **완전 동일** ✅ |
| `setup-node` | `node-version` | 유지 ✅ (`always-auth` 제거됐으나 사용 0건) |
| `upload-artifact` | `name`, `path` | 유지 ✅ |
| `upload-pages-artifact` | `path` | 유지 ✅ |
| `deploy-pages` | 출력 `page_url` | 유지 ✅ |
| `configure-pages` | (없음) | 입력 목록 v5·v6 동일 ✅ |

**동작 변경도 확인했습니다.**

| 변경 | 우리 영향 |
| --- | --- |
| `setup-node` v5: `packageManager` 필드 있으면 자동 캐싱 | **해당 없음** — 필드도 lock 파일도 없고 의존성 **0개** |
| `checkout` v7: `pull_request_target`·`workflow_run` 포크 PR 차단 | **해당 없음** — 두 트리거 사용 0건 |
| `checkout` v5: 러너 v2.327.1+ 필요 | GitHub 호스티드 러너는 최신이라 무관 |

### CI 실행 검증 — Node 20 경고 완전 소멸

```
Build  pass  9s

로그 내 'Node 20' 언급: 0건
받아진 액션: actions/checkout@v7, actions/setup-node@v7, actions/upload-artifact@v7
```

1차 수정 때 남아 있던 `upload-artifact` 경고까지 사라졌습니다.

### 실행 검증이 안 되는 워크플로

| 워크플로 | 트리거 | 이 PR에서 실행되나 |
| --- | --- | --- |
| `validation.yml` | `pull_request`, `push` | **실행됨 ✅** |
| `release.yml` | 태그 push | ❌ 다음 릴리스가 첫 실행 |
| `publish-chrome.yml` | `workflow_dispatch` | ❌ 수동 실행 시 |
| `publish-firefox.yml` | `workflow_dispatch` | ❌ 수동 실행 시 |
| `pages.yml` | `docs/**` push, `workflow_dispatch` | ❌ **이 PR은 워크플로만 바꿔 트리거 안 됨** |

**다섯 중 하나만 실행 검증됩니다.** 그래서 정적 검증을 두 겹으로 했습니다.

### 정적 검증

`actionlint`·`yamllint`·`pyyaml`·`js-yaml`이 모두 없었고 **설치하지 않았습니다.** macOS 기본 포함된 **Ruby의 Psych(YAML 파서)**를 썼습니다.

```
pages.yml            OK  jobs=1 steps=4 uses=4  트리거=push,workflow_dispatch
publish-chrome.yml   OK  jobs=1 steps=5 uses=2  트리거=workflow_dispatch
publish-firefox.yml  OK  jobs=1 steps=5 uses=2  트리거=workflow_dispatch
release.yml          OK  jobs=1 steps=6 uses=2  트리거=push
validation.yml       OK  jobs=1 steps=4 uses=3  트리거=pull_request,push
```

**모든 `uses` 참조가 실제 태그로 해석되는지**도 확인했습니다. YAML 파싱은 없는 버전 오타를 잡지 못합니다.

```
OK  actions/checkout@v7              → 3d3c42e
OK  actions/configure-pages@v6       → 45bfe01
OK  actions/deploy-pages@v5          → cd2ce8f
OK  actions/setup-node@v7            → 8207627
OK  actions/upload-artifact@v7       → 043fb46
OK  actions/upload-pages-artifact@v5 → fc324d3
```

### 회귀

```
ℹ tests 50   ℹ pass 50   ℹ fail 0
Dark icons are up to date. (117 icons)
Landing service data is up to date.
Landing icons are up to date.
Packaged 250 files into dist/linkhu-v2.5.0.zip.
```

## 💡 리뷰 포인트

**1. `pages.yml`은 이 PR에서 실행 검증이 안 됩니다**

`docs/**` 변경 push에서만 도는데 이 PR은 워크플로만 바꿉니다. 액션 4개를 모두 올렸으므로 정적 검증(파싱 + 태그 해석 + 입력·출력 계약)으로 대신했습니다. 머지 후 `docs/` 변경이 있을 때 첫 실행됩니다.

**2. `pages.yml`의 `checkout@v6 → v7`은 기능상 필요가 없습니다**

v6도 이미 node24입니다. 버전 통일 목적으로만 올렸습니다. 불필요한 변경이라 보시면 되돌리겠습니다.

**3. `upload-pages-artifact`는 자체 런타임이 없습니다**

composite라 `runs.using`만 보면 대상이 아닙니다. 중첩 의존성 때문에 올렸습니다.

## ✅ 체크리스트

- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요? — 기존 이슈 #130 사용
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요? — 런타임 전수 조회, YAML 파싱, 태그 해석, CI 실행
- [x] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? — 변경 없음
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요? — 문서 변경 없음 (워크플로 5개만)

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->
<!-- (이 주석은 화면에 보이지 않으며, AI 자동 리뷰를 한국어로 받기 위한 설정입니다.) -->
