### PR TITLE
refactor: 스크립트 중복 유틸 통합과 죽은 코드 정리

### DIFF
--- a/docs/landing.js
+++ b/docs/landing.js
@@ -10,9 +10,9 @@
     emailEntry: "entry.491031779",
   };
 
+  // src/shared.js의 normalize와 같은 규칙을 유지한다.
   function normalizeSearchText(value) {
     return String(value || "")
-      .trim()
       .toLocaleLowerCase("ko-KR")
       .replace(/\s+/g, "");
   }

--- a/scripts/generate-dark-icons.js
+++ b/scripts/generate-dark-icons.js
@@ -2,7 +2,8 @@ const fs = require("fs");
 const path = require("path");
 const zlib = require("zlib");
 
-const PROJECT_ROOT = path.resolve(__dirname, "..");
+const { PROJECT_ROOT, getCrc32 } = require("./lib");
+
 const SRC_ROOT = path.join(PROJECT_ROOT, "src");
 const IMAGES_ROOT = path.join(SRC_ROOT, "images");
 const DARK_ROOT = path.join(IMAGES_ROOT, "dark");
@@ -12,23 +13,6 @@ const DARK_ROOT = path.join(IMAGES_ROOT, "dark");
 const GRAY_TARGET = [0xa1, 0xa1, 0xaa];
 const RED_TARGET = [0xd9, 0x4a, 0x52];
 const DARK_CARD = [0x16, 0x16, 0x16];
-
-// package-extension.js와 같은 방식. zlib.crc32는 Node 22.2+에만 있어 쓰지 않는다.
-const CRC_TABLE = Array.from({ length: 256 }, (_, index) => {
-  let value = index;
-  for (let bit = 0; bit < 8; bit += 1) {
-    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
-  }
-  return value >>> 0;
-});
-
-function getCrc32(buffer) {
-  let crc = 0xffffffff;
-  for (const byte of buffer) {
-    crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
 
 function toLinear(value) {
   const v = value / 255;

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -1,0 +1,72 @@
+// scripts/ 전용 공용 유틸. 확장 소스(src/)에는 포함되지 않는다.
+const fs = require("fs");
+const path = require("path");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const MANIFEST_FILE = path.join(PROJECT_ROOT, "src", "manifest.json");
+
+// zlib.crc32는 Node 22.2+에만 있어 쓰지 않는다.
+const CRC_TABLE = Array.from({ length: 256 }, (_, index) => {
+  let value = index;
+  for (let bit = 0; bit < 8; bit += 1) {
+    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+  }
+  return value >>> 0;
+});
+
+function getCrc32(buffer) {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function readManifest() {
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST_FILE, "utf8"));
+  if (!manifest.version) {
+    throw new Error("src/manifest.json must include a version.");
+  }
+  return manifest;
+}
+
+function getRequiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} environment variable is required.`);
+  }
+  return value;
+}
+
+async function readResponseBody(response) {
+  const text = await response.text();
+  if (!text) return {};
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+// 스토어 배포 스크립트가 업로드할 ZIP 경로. envName 환경 변수로 재정의할 수 있다.
+function getPackageFile(label, envName) {
+  const packageFile =
+    process.env[envName] ||
+    path.join(PROJECT_ROOT, "dist", `linkhu-v${readManifest().version}.zip`);
+
+  if (!fs.existsSync(packageFile)) {
+    throw new Error(`${label} package file does not exist: ${packageFile}`);
+  }
+
+  return packageFile;
+}
+
+module.exports = {
+  PROJECT_ROOT,
+  getCrc32,
+  getPackageFile,
+  getRequiredEnv,
+  readManifest,
+  readResponseBody,
+};

--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -1,26 +1,10 @@
 const fs = require("fs");
 const path = require("path");
 
-const PROJECT_ROOT = path.resolve(__dirname, "..");
+const { PROJECT_ROOT, getCrc32, readManifest } = require("./lib");
+
 const SRC_ROOT = path.join(PROJECT_ROOT, "src");
 const DIST_ROOT = path.join(PROJECT_ROOT, "dist");
-const MANIFEST_FILE = path.join(SRC_ROOT, "manifest.json");
-
-const CRC_TABLE = Array.from({ length: 256 }, (_, index) => {
-  let value = index;
-  for (let bit = 0; bit < 8; bit += 1) {
-    value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
-  }
-  return value >>> 0;
-});
-
-function getCrc32(buffer) {
-  let crc = 0xffffffff;
-  for (const byte of buffer) {
-    crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
 
 // ZIP의 최소 표현 시각(1980-01-01 00:00:00)을 사용해 체크아웃 시각과 무관한
 // 재현 가능한 패키지를 생성한다.
@@ -37,14 +21,6 @@ function createUInt32(value) {
   const buffer = Buffer.alloc(4);
   buffer.writeUInt32LE(value >>> 0);
   return buffer;
-}
-
-function readManifest() {
-  const manifest = JSON.parse(fs.readFileSync(MANIFEST_FILE, "utf8"));
-  if (!manifest.version) {
-    throw new Error("src/manifest.json must include a version.");
-  }
-  return manifest;
 }
 
 function collectFiles(directory, baseDirectory = directory) {

--- a/scripts/publish-chrome.js
+++ b/scripts/publish-chrome.js
@@ -1,35 +1,12 @@
 const fs = require("fs");
 const path = require("path");
 
-const PROJECT_ROOT = path.resolve(__dirname, "..");
-const MANIFEST_FILE = path.join(PROJECT_ROOT, "src", "manifest.json");
-
-function getRequiredEnv(name) {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`${name} environment variable is required.`);
-  }
-  return value;
-}
-
-function readManifestVersion() {
-  const manifest = JSON.parse(fs.readFileSync(MANIFEST_FILE, "utf8"));
-  if (!manifest.version) {
-    throw new Error("src/manifest.json must include a version.");
-  }
-  return manifest.version;
-}
-
-async function readResponseBody(response) {
-  const text = await response.text();
-  if (!text) return {};
-
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
-}
+const {
+  PROJECT_ROOT,
+  getPackageFile,
+  getRequiredEnv,
+  readResponseBody,
+} = require("./lib");
 
 async function requestJson(label, url, options) {
   const response = await fetch(url, options);
@@ -41,19 +18,6 @@ async function requestJson(label, url, options) {
   }
 
   return body;
-}
-
-function getPackageFile() {
-  const manifestVersion = readManifestVersion();
-  const packageFile =
-    process.env.CHROME_PACKAGE_FILE ||
-    path.join(PROJECT_ROOT, "dist", `linkhu-v${manifestVersion}.zip`);
-
-  if (!fs.existsSync(packageFile)) {
-    throw new Error(`Chrome package file does not exist: ${packageFile}`);
-  }
-
-  return packageFile;
 }
 
 async function getAccessToken(clientId, clientSecret, refreshToken) {
@@ -125,7 +89,7 @@ async function fetchStatus(accessToken, publisherId, extensionId) {
 
 async function main() {
   try {
-    const packageFile = getPackageFile();
+    const packageFile = getPackageFile("Chrome", "CHROME_PACKAGE_FILE");
     const publisherId = getRequiredEnv("CHROME_PUBLISHER_ID");
     const extensionId = getRequiredEnv("CHROME_EXTENSION_ID");
     const relativePackageFile = path.relative(PROJECT_ROOT, packageFile);

--- a/scripts/publish-firefox.js
+++ b/scripts/publish-firefox.js
@@ -2,8 +2,14 @@ const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 
-const PROJECT_ROOT = path.resolve(__dirname, "..");
-const MANIFEST_FILE = path.join(PROJECT_ROOT, "src", "manifest.json");
+const {
+  PROJECT_ROOT,
+  getPackageFile,
+  getRequiredEnv,
+  readManifest,
+  readResponseBody,
+} = require("./lib");
+
 const DEFAULT_API_BASE_URL = "https://addons.mozilla.org/api/v5";
 const DEFAULT_LICENSE = "MIT";
 const DEFAULT_POLL_INTERVAL_MS = 10000;
@@ -11,37 +17,8 @@ const DEFAULT_POLL_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_RELEASE_NOTES_LOCALE = "ko";
 const JWT_EXPIRATION_SECONDS = 5 * 60;
 
-function getRequiredEnv(name) {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`${name} environment variable is required.`);
-  }
-  return value;
-}
-
-function readManifestVersion() {
-  const manifest = JSON.parse(fs.readFileSync(MANIFEST_FILE, "utf8"));
-  if (!manifest.version) {
-    throw new Error("src/manifest.json must include a version.");
-  }
-  return manifest.version;
-}
-
-function getPackageFile() {
-  const manifestVersion = readManifestVersion();
-  const packageFile =
-    process.env.FIREFOX_PACKAGE_FILE ||
-    path.join(PROJECT_ROOT, "dist", `linkhu-v${manifestVersion}.zip`);
-
-  if (!fs.existsSync(packageFile)) {
-    throw new Error(`Firefox package file does not exist: ${packageFile}`);
-  }
-
-  return packageFile;
-}
-
 function getReleaseNotesFile() {
-  const manifestVersion = readManifestVersion();
+  const manifestVersion = readManifest().version;
   const releaseNotesFile =
     process.env.FIREFOX_RELEASE_NOTES_FILE ||
     path.join(PROJECT_ROOT, "release-notes", `v${manifestVersion}.md`);
@@ -85,17 +62,6 @@ function createJwt(issuer, secret) {
     .replace(/\//g, "_");
 
   return `${unsignedToken}.${signature}`;
-}
-
-async function readResponseBody(response) {
-  const text = await response.text();
-  if (!text) return {};
-
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
 }
 
 async function requestJson(label, url, options, credentials) {
@@ -217,7 +183,7 @@ async function main() {
   try {
     const apiBaseUrl = process.env.FIREFOX_API_BASE_URL || DEFAULT_API_BASE_URL;
     const addonId = getRequiredEnv("FIREFOX_ADDON_ID");
-    const packageFile = getPackageFile();
+    const packageFile = getPackageFile("Firefox", "FIREFOX_PACKAGE_FILE");
     const releaseNotesFile = getReleaseNotesFile();
     const releaseNotesLocale =
       process.env.FIREFOX_RELEASE_NOTES_LOCALE || DEFAULT_RELEASE_NOTES_LOCALE;

--- a/spec/3-1-DESIGN-SOFTWARE-ARCHITECTURE.md
+++ b/spec/3-1-DESIGN-SOFTWARE-ARCHITECTURE.md
@@ -60,7 +60,6 @@ options.html  <head> theme.js
 | 함수 | 보장하는 것 |
 | --- | --- |
 | `normalize(value)` | `ko-KR` 기준 소문자화 + 모든 공백 제거 |
-| `matchesSearch(site, q)` | 이름·id·카테고리 중 하나라도 포함하면 참 |
 | `scoreSite(site, q)` | 0~4 점수. 낮을수록 상위. 해당 없으면 `Infinity` |
 | `rankSites(sites, q)` | 점수 오름차순, 동점이면 원본 배열 순서 유지 |
 | `getDefaultOrder(list)` | `공통` 카테고리 서비스의 id 배열 |

--- a/src/options.css
+++ b/src/options.css
@@ -367,13 +367,10 @@ h1 {
   overflow: visible;
   clip: auto;
   white-space: normal;
-  color: var(--color-notice);
-  text-align: center;
-}
-
-.theme-status-visible {
   margin: 10px 0 0;
+  color: var(--color-notice);
   font-size: 12px;
+  text-align: center;
 }
 
 .options-footer {
@@ -477,16 +474,4 @@ h1 {
   color: var(--color-text-muted);
   font-size: 12px;
   text-align: right;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }

--- a/src/popup.css
+++ b/src/popup.css
@@ -19,16 +19,28 @@ body {
 
 header {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-  margin-bottom: 15px;
+  margin-bottom: 10px;
+}
+
+.header-title {
+  display: flex;
+  align-items: baseline;
 }
 
 header h1 {
   margin: 0;
   font-size: 20px;
   font-weight: 700;
+  line-height: 1;
   color: var(--color-primary);
+}
+
+#current-version {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  margin-left: 8px;
 }
 
 .search-bar {
@@ -334,11 +346,8 @@ header h1 {
   overflow: visible;
   clip: auto;
   white-space: normal;
-  color: var(--color-notice);
-  text-align: center;
-}
-
-.theme-status-visible {
   margin: 0 0 8px;
+  color: var(--color-notice);
   font-size: 11.5px;
+  text-align: center;
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -11,31 +11,10 @@
   </head>
   <body>
     <div class="container">
-      <header
-        style="
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          width: 100%;
-          margin-bottom: 10px;
-        "
-      >
-        <div style="display: flex; align-items: baseline;">
-          <h1
-            style="
-              margin: 0;
-              font-size: 20px;
-              font-weight: 700;
-              color: var(--color-primary);
-              line-height: 1;
-            "
-          >
-            LinKHU
-          </h1>
-          <span
-            id="current-version"
-            style="font-size: 12px; color: var(--color-text-muted); margin-left: 8px;"
-          ></span>
+      <header>
+        <div class="header-title">
+          <h1>LinKHU</h1>
+          <span id="current-version"></span>
           <span id="update-message"></span>
         </div>
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -8,12 +8,6 @@ const LinKHUShared = {
       .replace(/\s+/g, "");
   },
 
-  matchesSearch(site, normalizedQuery) {
-    return [site.name, site.id, site.category].some((value) =>
-      this.normalize(value).includes(normalizedQuery),
-    );
-  },
-
   // 점수가 낮을수록 상위 노출. 랜딩 페이지(docs/landing.js)의 scoreService와
   // 같은 규칙을 유지해야 팝업과 랜딩의 검색 결과 순서가 일치한다.
   scoreSite(site, normalizedQuery) {

--- a/src/version.js
+++ b/src/version.js
@@ -1,9 +1,4 @@
 const VersionManager = {
-  async getCurrentVersion() {
-    const manifest = chrome.runtime.getManifest();
-    return manifest.version;
-  },
-
   // GitHub API rate limit 때문에 최신 릴리스 버전은 12시간 캐싱한다.
   async getLatestGithubReleaseVersion() {
     const CACHE_KEY = "latestReleaseVersion";
@@ -31,12 +26,12 @@ const VersionManager = {
         return cachedVersion || null;
       }
       const data = await response.json();
-      const version = data.tag_name ? data.tag_name.replace(/^v/, '') : null;
+      const version = data.tag_name ? data.tag_name.replace(/^v/, "") : null;
 
       if (version) {
         await chrome.storage.local.set({
           [CACHE_KEY]: version,
-          [CACHE_TIME_KEY]: now
+          [CACHE_TIME_KEY]: now,
         });
       }
       return version;
@@ -47,8 +42,8 @@ const VersionManager = {
   },
 
   compareVersions(v1, v2) {
-    const parts1 = (v1 || '0.0.0').split('.').map(Number);
-    const parts2 = (v2 || '0.0.0').split('.').map(Number);
+    const parts1 = (v1 || "0.0.0").split(".").map(Number);
+    const parts2 = (v2 || "0.0.0").split(".").map(Number);
     for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
       const p1 = parts1[i] || 0;
       const p2 = parts2[i] || 0;
@@ -58,7 +53,7 @@ const VersionManager = {
     return 0;
   },
 
-  async getUpdateLink() {
+  getUpdateLink() {
     let link = "https://github.com/kangkyunghyun/LinKHU/releases/latest";
     try {
       // 스토어 update_url이 없으면 unpacked 개발 모드로 보고 GitHub 릴리스로 안내한다.
@@ -81,10 +76,8 @@ const VersionManager = {
   },
 
   async displayVersionInfo(currentVersionElId, updateMessageElId) {
-    const [currentVersion, latestVersion] = await Promise.all([
-      this.getCurrentVersion(),
-      this.getLatestGithubReleaseVersion()
-    ]);
+    const currentVersion = chrome.runtime.getManifest().version;
+    const latestVersion = await this.getLatestGithubReleaseVersion();
 
     const currentVersionEl = document.getElementById(currentVersionElId);
     const updateMessageEl = document.getElementById(updateMessageElId);
@@ -95,19 +88,17 @@ const VersionManager = {
 
     if (updateMessageEl && latestVersion) {
       if (this.compareVersions(currentVersion, latestVersion) < 0) {
-        const storeLink = await this.getUpdateLink();
-
-        const updateLink = document.createElement('a');
-        updateLink.href = storeLink;
-        updateLink.target = '_blank';
-        updateLink.className = 'update-link';
+        const updateLink = document.createElement("a");
+        updateLink.href = this.getUpdateLink();
+        updateLink.target = "_blank";
+        updateLink.className = "update-link";
         updateLink.textContent = `(업데이트 가능: v${latestVersion})`;
         updateMessageEl.replaceChildren(updateLink);
       } else {
-        updateMessageEl.textContent = '';
+        updateMessageEl.textContent = "";
       }
     }
-  }
+  },
 };
 
 if (typeof module !== "undefined" && module.exports) {

--- a/tests/shared.test.js
+++ b/tests/shared.test.js
@@ -9,18 +9,6 @@ test("shared normalize removes spaces and letter case", () => {
   assert.equal(LinKHUShared.normalize(null), "");
 });
 
-test("shared matchesSearch matches name, id, and category", () => {
-  const site = { id: "software", name: "소프트웨어 융합대학", category: "단과대" };
-
-  assert.equal(
-    LinKHUShared.matchesSearch(site, LinKHUShared.normalize("소프트웨어융합 대학")),
-    true,
-  );
-  assert.equal(LinKHUShared.matchesSearch(site, "software"), true);
-  assert.equal(LinKHUShared.matchesSearch(site, "단과대"), true);
-  assert.equal(LinKHUShared.matchesSearch(site, "없는검색어"), false);
-});
-
 test("shared rankSites orders by name prefix, name, id, then category", () => {
   const sites = [
     { id: "swcon", name: "소프트웨어융합학과", category: "학과" },


### PR DESCRIPTION
## 📝 요약
코드 전체 점검에서 나온 중복·죽은 코드를 정리했습니다. 스크립트 공용 유틸을 `scripts/lib.js` 한 곳으로 모으고, 프로덕션 미사용 코드와 인라인 스타일-CSS 충돌을 제거했습니다. 동작 변경은 없습니다. 전체 diff는 13개 파일 +129/−222입니다.

## ⚙️ 작업 사항
- [x] `scripts/lib.js` 신설: CRC32(2벌), manifest 읽기(3벌), `getRequiredEnv`·`readResponseBody`·`getPackageFile`(각 2벌) 통합
- [x] `src/shared.js` 미사용 `matchesSearch` 삭제 + `spec/3-1` API 표 함께 갱신
- [x] `popup.html` 인라인 헤더 스타일을 `popup.css`로 이동, 충돌하던 죽은 `header` 규칙 제거
- [x] `options.css` 미사용 `.sr-only` 삭제, 두 CSS의 중복 `.theme-status-visible` 블록 병합
- [x] `version.js` 불필요한 async 제거·따옴표 통일
- [x] `docs/landing.js` `normalizeSearchText`의 중복 `.trim()` 제거 (shared의 `normalize`와 문자 그대로 동일해짐)

## 📌 관련 이슈
- Close #134

## 🧪 테스트 결과
- `npm test`: 49개 전부 통과
- `npm run validate:data`: Data validation passed (경고 1건은 기존 http URL 안내로 본 PR과 무관)
- `npm run validate:dark-icons`: Dark icons are up to date. (117 icons)
- `npm run validate:landing-data`: Landing service data/icons are up to date
- `npm run package`: 250개 파일 → `dist/linkhu-v2.5.0.zip` 정상 생성
- publish 스크립트 dry run: `CHROME_DRY_RUN`/`FIREFOX_DRY_RUN` 모두 정상 (lib 연결 확인)
- 삭제 심볼 잔존 참조 검색: `matchesSearch` 등 0건 (src/docs/spec/scripts/tests/.github 전체 grep)
- 인라인→CSS 이동은 속성 단위 대조로 시각 동일성 확인 (유일하게 뺀 `width:100%`는 블록 레벨 flex 기본값과 동일)

## 💡 리뷰 포인트
- `getPackageFile`이 `*_PACKAGE_FILE` 환경 변수 지정 시 manifest를 읽지 않게 된 단락 평가 차이(기존은 항상 읽음)를 개선으로 봤는데 괜찮을까요?
- `theme.js\'와 shared↔landing 검색 로직 중복은 의도된 설계(스펙 3-2-5, GitHub Pages 제약)로 보고 유지했습니다.

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (data.js 변경 없음, 검증은 통과 확인)
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요? (spec/3-1 API 표 갱신)

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->