### PR TITLE
feat: 랜딩 페이지 GA4 연결 및 스토어 링크 클릭 이벤트 추가

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,30 @@
     <title>LinKHU — 경희대 웹서비스를 한곳에</title>
     <link rel="icon" type="image/png" href="assets/linkhu-icon.png">
     <link rel="stylesheet" href="landing.css">
+
+    <!-- Google tag (gtag.js) — 랜딩 페이지 방문·스토어 클릭 측정 전용 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NHV31WF5ZM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-NHV31WF5ZM');
+
+      // 스토어 설치 링크 클릭을 전환 이벤트로 보낸다. 링크가 여러 곳에 있어 위임 방식 하나로 처리한다.
+      (function () {
+        var STORE_EVENTS = {
+          "chromewebstore.google.com": "click_chrome_store",
+          "addons.mozilla.org": "click_firefox_store",
+          "store.whale.naver.com": "click_whale_store",
+        };
+        document.addEventListener("click", function (event) {
+          var link = event.target.closest ? event.target.closest("a[href]") : null;
+          if (!link) return;
+          var eventName = STORE_EVENTS[link.hostname];
+          if (eventName) gtag("event", eventName);
+        });
+      })();
+    </script>
   </head>
   <body>
     <a class="skip-link" href="#main-content">본문으로 바로가기</a>


### PR DESCRIPTION
## 📝 요약
> 랜딩 페이지(`docs/index.html`)에 GA4(측정 ID `G-NHV31WF5ZM`, LinKHU 홈페이지 전용 속성) 스니펫을 추가하고, 스토어 설치 링크 클릭을 `click_chrome_store` / `click_firefox_store` / `click_whale_store` 이벤트로 전송합니다. 9월 개강기 UTM 유입 실험의 측정 기반입니다.

## ⚙️ 작업 사항
- [x] `<head>`에 gtag 스니펫 추가 (홈페이지 전용 신규 GA4 속성)
- [x] 스토어 링크 클릭 이벤트: 링크가 여러 곳(히어로·설치 섹션·푸터)에 있어 호스트명 기반 위임 리스너 하나로 처리
- [ ] GA4 관리 화면에서 위 3개 이벤트를 주요 이벤트(전환)로 지정 — 머지·배포 후 수동 작업

## 📌 관련 이슈
- Close #137

## 🧪 테스트 결과
- `npm test` 통과 (fail 0)
- 실측 검증은 GitHub Pages 특성상 머지 후 가능: 배포된 페이지 접속 → GA4 실시간 보고서에 페이지뷰 확인, 스토어 버튼 클릭 → DebugView에서 이벤트 확인 예정

## 💡 리뷰 포인트
- 이벤트 전송을 개별 링크 `onclick` 대신 문서 위임 방식으로 묶었는데, 링크가 추가돼도 자동 커버되는 대신 index.html 인라인 스크립트가 24줄 늘었습니다. 적절한 트레이드오프인지 봐주세요.
- 확장 프로그램 내부에는 어떤 수집 코드도 넣지 않았습니다 (`data_collection_permissions: "none"` 유지).

## ✅ 체크리스트
- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [ ] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (해당 없음)
- [ ] 문서(Wiki, API Docs 등)를 업데이트했나요? (해당 없음)