### PR TITLE
docs: 랜딩 페이지 제목 구분 기호를 en dash로

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,14 +8,14 @@
       content="경희대학교 학생을 위한 웹서비스 바로가기 브라우저 확장 프로그램, LinKHU"
     >
     <meta name="theme-color" content="#a40f16">
-    <meta property="og:title" content="LinKHU — 경희대 웹서비스를 한곳에">
+    <meta property="og:title" content="LinKHU – 경희대 웹서비스를 한곳에">
     <meta
       property="og:description"
       content="인포21부터 e-Campus, 수강신청까지. 자주 쓰는 경희대 웹서비스를 클릭 한 번으로 여세요."
     >
     <meta property="og:type" content="website">
     <meta property="og:image" content="assets/store/promotion-tile.png">
-    <title>LinKHU — 경희대 웹서비스를 한곳에</title>
+    <title>LinKHU – 경희대 웹서비스를 한곳에</title>
     <link rel="icon" type="image/png" href="assets/linkhu-icon.png">
     <link rel="stylesheet" href="landing.css">
 


### PR DESCRIPTION
## 📝 요약

랜딩 페이지의 문서 제목과 og:title에서 이름과 설명을 잇던 em dash(`—`)를 en dash(`–`)로 바꿉니다. 브라우저 탭에서 폭을 덜 차지합니다.

## ⚙️ 작업 사항

- [x] `docs/index.html`의 `<title>`을 en dash로 변경
- [x] `docs/index.html`의 `<meta property="og:title">`을 en dash로 변경

같은 파일 22행(`<!-- Google tag (gtag.js) — ... -->`)의 em dash는 그대로 뒀습니다. HTML 주석이라 사용자에게 보이지 않고, 저장소 전체 주석·문서가 em dash를 쓰고 있어 여기만 바꾸면 오히려 어긋납니다.

## 📌 관련 이슈

- Close #163

## 🧪 테스트 결과

| 확인 | 결과 |
| --- | --- |
| `grep -c "LinKHU —" docs/index.html` | `0` — em dash 잔여 없음 |
| `git show --stat HEAD` | `docs/index.html \| 4 ++--` — 변경 파일 1개 |
| `git diff --check` | 출력 없음 |

`src/` 변경이 없어 확장 동작에는 영향이 없습니다. 데이터 변경도 없습니다.

## 💡 리뷰 포인트

- 주석 안 em dash를 남긴 판단이 맞는지. 저장소 전체를 en dash로 통일할 생각이라면 별도 작업으로 다루는 게 낫다고 봤습니다.

## ✅ 체크리스트

- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요? (해당 없음)

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->