### PR TITLE
fix: 릴리스 파이프라인에서 v2.7.0 배포 중 드러난 문제 3건

### DIFF
--- a/docs/chrome-web-store-automation.md
+++ b/docs/chrome-web-store-automation.md
@@ -54,7 +54,8 @@ Chrome access token request failed (400): {"error":"invalid_grant","error_descri
 ```
 
 - 입력값 오류는 증상이 다르다. `confirm_publish`가 `publish-chrome`이 아니면 그 앞 `Verify release input` 단계에서 `confirm_publish must be publish-chrome.`로 걸린다.
-- 즉 **어느 단계에서 멈췄는지를 먼저 본다.** `Verify release input`이면 입력값 문제이고, `Publish to Chrome Web Store`면 토큰 문제다.
+- 즉 **어느 단계에서 멈췄는지를 먼저 본다.** `Verify release input`이면 입력값 문제다.
+- `Publish to Chrome Web Store`에서 멈췄다면 **응답 본문으로 갈린다.** `invalid_grant`면 토큰 문제이고, `NOT_UPDATEABLE`이면 아래 [심사 중 업로드 실패 대응](#심사-중-업로드-실패-대응)이다.
 
 ### 원인
 
@@ -140,6 +141,38 @@ Google Cloud OAuth 동의 화면의 게시 상태가 **테스트(Testing)**이�
 같은 배포에서 서로 다른 두 오류를 순서대로 겪었다. 위 [증상](#증상) 절의 단계 구분이 여기서 나왔다.
 
 재발급한 토큰의 스코프는 `chromewebstore` 하나뿐이었다. 같은 날 OAuth 동의 화면을 프로덕션으로 전환해 만료 문제를 없앴다.
+
+## 심사 중 업로드 실패 대응
+
+### 증상
+
+`Publish to Chrome Web Store` 단계에서 다음 오류가 나면 아이템이 이미 심사 중인 것이다.
+
+```text
+400: {"error":{"code":400,"message":"You may not edit or publish an item that is in review.","status":"FAILED_PRECONDITION","details":[{"reason":"NOT_UPDATEABLE"}]}}
+```
+
+- 같은 단계에서 나는 `invalid_grant`와 구분한다. 그쪽은 토큰 문제이고 [토큰 만료 대응](#토큰-만료-대응)을 따른다.
+- 판별 기준은 응답 본문이다. `NOT_UPDATEABLE`이 보이면 아래로 온다.
+
+### 원인
+
+Chrome Web Store는 **심사 중인 아이템에 새 패키지를 올리거나 publish 요청을 보내는 것을 막는다.** 이전 버전을 제출한 뒤 심사가 끝나기 전에 워크플로우를 다시 실행하면 이 응답이 온다.
+
+### 대응
+
+**우리 쪽에서 고칠 것이 없다** (MUST). 토큰, secret, 워크플로우 입력값은 모두 정상이다.
+
+- **토큰을 재발급하지 않는다.** 이 오류는 인증 문제가 아니므로 재발급해도 같은 응답이 온다.
+- Chrome Web Store Developer Dashboard에서 이전 제출의 심사 상태를 확인한다.
+- 심사가 끝난 뒤 같은 입력으로 워크플로우를 재실행한다.
+
+```bash
+gh workflow run publish-chrome.yml --ref main \
+  -f version={version} -f confirm_publish=publish-chrome
+```
+
+심사 소요 시간은 Google이 정하며 우리가 앞당길 수 없다. 기다리는 것이 유일한 대응이다.
 
 ## 참고 문서
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -8,6 +8,27 @@ LinKHU 릴리스와 스토어 배포 절차입니다.
 - `release-notes/v{version}.md`를 기존 형식에 맞춰 작성한다. (사용자 노출 변경 중심)
 - PR을 `main`에 머지한다.
 
+### 스토어·커뮤니티 문구 PR도 여기서 머지한다
+
+**태그를 밀기 전에 `docs/store-listing.md`와 `docs/community-post.md` 갱신을 끝내 머지한다** (MUST).
+문구 작성 기준은 `.claude/skills/release-copy/SKILL.md`에 있다. 준비 PR에 함께 담아도 되고 별도 PR로 나눠도 되지만,
+**둘 다 태그 push보다 앞에 온다.**
+
+이유는 두 가지가 겹쳐서다.
+
+- `scripts/validate-release.js`가 **태그가 체크아웃된 커밋을 가리키는지** 검사한다.
+- `publish-chrome.yml`·`publish-firefox.yml`은 **`main`에서만** 실행된다.
+
+즉 **태그가 `main`의 tip일 때만 스토어 배포가 통과한다.** 태그를 민 뒤에 다른 PR을 머지하면 `main`이 태그보다 앞서고,
+3번의 스토어 배포가 이 오류로 막힌다.
+
+```text
+- Release tag v2.7.0 points to 6d3677a, but the checked out commit is 3f3fe84.
+```
+
+이미 어긋났다면 태그를 `main` tip으로 옮겨 해결할 수 있지만, **이미 공개된 태그를 force-push하게 된다.**
+GitHub Release가 가리키는 커밋도 함께 바뀌므로, 순서를 지켜 애초에 이 상황을 만들지 않는 편이 낫다.
+
 ## 2. 태그 push → GitHub Release 자동 생성
 
 ```bash
@@ -23,8 +44,10 @@ git push origin "v$VERSION"
 
 ## 3. 스토어 배포
 
+문구 원본 두 개는 **1번에서 이미 머지되어 있어야 한다.** 여기서는 붙여넣기만 한다.
+
 - 공통 절차: [Store Release Checklist](./store-release-checklist.md)
-- 스토어 설명 원본: [Store Listing](./store-listing.md) — 버전마다 업데이트 섹션을 교체한다.
+- 스토어 설명 원본: [Store Listing](./store-listing.md) — 버전마다 업데이트 섹션을 교체한다. (교체는 1번에서)
 - 커뮤니티 홍보 글 원본: [Community Post](./community-post.md) — 커뮤니티에 올릴 때 사용한다.
 - 두 문구 작성 기준: `.claude/skills/release-copy/SKILL.md`
 - Chrome Web Store: [자동 배포 워크플로우](./chrome-web-store-automation.md)

--- a/scripts/publish-firefox.js
+++ b/scripts/publish-firefox.js
@@ -30,6 +30,24 @@ function getReleaseNotesFile() {
   return releaseNotesFile;
 }
 
+// AMO 릴리스 노트에는 내부 변경을 싣지 않는다. 사람이 붙여넣는 스토어 문구에만 걸려 있던
+// 규칙이라 자동 배포 경로로 그대로 새어 나갔다(v2.7.0). release-notes/*.md 원본은 저장소
+// 기록이므로 그대로 두고, 보내기 직전에만 거른다.
+function stripInternalSection(releaseNotes) {
+  const kept = [];
+  let skipping = false;
+
+  String(releaseNotes)
+    .split("\n")
+    .forEach((line) => {
+      // 다음 헤딩을 만나면 다시 살린다. Internal이 마지막 섹션이 아닐 수도 있다.
+      if (line.startsWith("### ")) skipping = line.trim() === "### Internal";
+      if (!skipping) kept.push(line);
+    });
+
+  return `${kept.join("\n").trimEnd()}\n`;
+}
+
 function base64UrlEncode(value) {
   return Buffer.from(value)
     .toString("base64")
@@ -204,7 +222,9 @@ async function main() {
       issuer: getRequiredEnv("FIREFOX_JWT_ISSUER"),
       secret: getRequiredEnv("FIREFOX_JWT_SECRET"),
     };
-    const releaseNotes = await fs.promises.readFile(releaseNotesFile, "utf8");
+    const releaseNotes = stripInternalSection(
+      await fs.promises.readFile(releaseNotesFile, "utf8"),
+    );
     const uploadResponse = await uploadPackage(apiBaseUrl, credentials, packageFile);
     console.log(`Firefox upload response: ${JSON.stringify(uploadResponse, null, 2)}`);
 
@@ -230,4 +250,10 @@ async function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  stripInternalSection,
+};

--- a/spec/5-TESTING.md
+++ b/spec/5-TESTING.md
@@ -15,7 +15,7 @@ LinKHU는 확장 프로그램 UI가 제품의 대부분이라, 자동 테스트�
 
 ## 5-1 자동 테스트
 
-`npm test`는 Node 내장 테스트 러너(`node --test`)로 `tests/`를 실행한다. 2026-08-31 기준 9개 파일 68개 테스트다. 테스트 프레임워크를 따로 두지 않는다 — 의존성 없는 구성([3-3](3-3-DESIGN-DECISIONS.md))을 유지하기 위해서다.
+`npm test`는 Node 내장 테스트 러너(`node --test`)로 `tests/`를 실행한다. 2026-08-31 기준 10개 파일 71개 테스트다. 테스트 프레임워크를 따로 두지 않는다 — 의존성 없는 구성([3-3](3-3-DESIGN-DECISIONS.md))을 유지하기 위해서다.
 
 | 파일 | 고정하는 것 |
 | --- | --- |
@@ -28,6 +28,7 @@ LinKHU는 확장 프로그램 UI가 제품의 대부분이라, 자동 테스트�
 | `feedback.test.js` | 문의 설정 여부 판정, 전송 대상 필드, 이메일 선택 포함 |
 | `landing-feedback.test.js` | 랜딩과 확장의 문의 전송 일치 |
 | `package-extension.test.js` | 패키징 산출물의 재현 가능성 |
+| `publish-firefox.test.js` | 스토어로 보낼 릴리스 노트에서 `### Internal` 제거 |
 
 특히 중요한 두 테스트가 있다.
 

--- a/tests/publish-firefox.test.js
+++ b/tests/publish-firefox.test.js
@@ -1,0 +1,57 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const { stripInternalSection } = require("../scripts/publish-firefox");
+
+const RELEASE_NOTES_ROOT = path.join(__dirname, "..", "release-notes");
+
+function readReleaseNotes(fileName) {
+  return fs.readFileSync(path.join(RELEASE_NOTES_ROOT, fileName), "utf8");
+}
+
+test("AMO로 보내는 릴리스 노트에서 Internal 섹션이 빠진다", () => {
+  const stripped = stripInternalSection(readReleaseNotes("v2.7.0.md"));
+
+  assert.ok(!stripped.includes("### Internal"));
+  assert.ok(!stripped.includes("폭 가드 추가"));
+  assert.ok(!stripped.includes("en dash"));
+  assert.ok(!stripped.includes("스토어 스크린샷"));
+
+  // 사용자에게 보이는 두 섹션은 그대로 남는다.
+  assert.ok(stripped.includes("### Features"));
+  assert.ok(stripped.includes("설정 페이지 목록에서 각 서비스를 새 탭으로 열어볼 수 있습니다"));
+  assert.ok(stripped.includes("### Fixes"));
+  assert.ok(stripped.includes("`환경학및환경공학과`를 `환경학 및 환경공학과`로 정정했습니다"));
+});
+
+test("Internal 섹션이 없는 릴리스 노트는 그대로 통과한다", () => {
+  // v2.3.1은 Features 하나뿐인 실제 릴리스 노트다.
+  const original = readReleaseNotes("v2.3.1.md");
+
+  assert.ok(!original.includes("### Internal"));
+  assert.equal(stripInternalSection(original), original);
+});
+
+test("Internal이 마지막 섹션이 아니어도 그 뒤 섹션이 살아남는다", () => {
+  const notes = [
+    "### Features",
+    "",
+    "- 새 기능",
+    "",
+    "### Internal",
+    "",
+    "- 내부 변경",
+    "",
+    "### Fixes",
+    "",
+    "- 고친 것",
+    "",
+  ].join("\n");
+
+  assert.equal(
+    stripInternalSection(notes),
+    ["### Features", "", "- 새 기능", "", "### Fixes", "", "- 고친 것", ""].join("\n"),
+  );
+});


### PR DESCRIPTION
> [!WARNING]
> **Chrome 제출이 끝나기 전에 머지하면 안 됩니다.** 머지하면 `main`이 `v2.7.0` 태그보다 앞서서 아래 1번 문제가 그대로 재현되고, 대기 중인 Chrome 배포가 다시 막힙니다. 이 PR이 고치는 함정에 이 PR이 걸리는 구조입니다.

## 📝 요약

v2.7.0 스토어 배포를 실제로 진행하면서 드러난 세 가지를 고칩니다. 셋 다 다음 릴리스에서 그대로 반복됩니다.

## ⚙️ 작업 사항

- [x] **`docs/release-process.md`** — 문구 PR을 태그 push 전에 머지하도록 순서 제약 명시
- [x] **`docs/chrome-web-store-automation.md`** — `NOT_UPDATEABLE`(심사 중) 실패 케이스 추가
- [x] **`scripts/publish-firefox.js`** — 보낼 릴리스 노트에서 `### Internal` 제거
- [x] `tests/publish-firefox.test.js` 신규 3건
- [x] `spec/5-TESTING.md` 테스트 파일 표·수치 갱신

## 📌 관련 이슈

- Close #171

## 🧪 테스트 결과

| 명령 | 결과 |
| --- | --- |
| `npm test` | 71 tests / 71 pass / 0 fail (68 → 3 추가) |
| `npm run validate:data` | `Validated 165 sites.` / `Data validation passed.` |
| `git diff --check` | 출력 없음 |

**`release-notes/` 전체에 제거 함수를 돌려 확인**했습니다. 7개 중 6개에 `### Internal`이 있었고 전부 제거됐으며, 없는 하나(`v2.3.1.md`)는 바이트 단위로 동일합니다. 본문이 잘려나가거나 헤딩만 남는 파일은 없고, 끝에 빈 줄이 늘어지지도 않습니다.

**`require.main` 가드 확인**: `.github/workflows/publish-firefox.yml:63`이 `node scripts/publish-firefox.js`로 직접 실행하므로 `require.main === module`이 참이고 배포 동작은 그대로입니다. `require`로 불러도 배포가 돌지 않는 것을 확인했습니다.

## 💡 리뷰 포인트

- **`### 증상` 절의 단정을 함께 고쳤습니다.** 기존 문서가 "`Publish to Chrome Web Store`면 토큰 문제다"라고 단정하고 있었는데, 새 오류도 같은 단계에서 납니다. 그대로 두면 다음 사람이 정확히 이 함정(토큰부터 재발급)에 빠집니다. 응답 본문으로 갈리도록 바꿨습니다.
- **`stripInternalSection`을 정규식이 아니라 줄 단위 순회로 짰습니다.** 다음 `###`에서 자동으로 다시 켜지므로 Internal이 중간에 있어도 뒤 섹션이 살아남습니다.
- **`### Internal` 판정을 정확히 일치로 했습니다.** `### internal`(소문자)이나 `###Internal`(공백 없음)은 걸리지 않습니다. 저장소 7개 파일이 모두 `### Internal`이라 지금은 문제가 없지만, 형식이 흔들리면 조용히 통과합니다. 느슨하게 잡을지 판단 부탁드립니다.
- **`publish-firefox.js`에 `require.main` 가드를 넣었습니다.** 테스트가 `require`하려면 필요합니다. 저장소의 다른 스크립트 5개가 쓰는 관례를 따랐습니다. `publish-chrome.js`도 같은 형태지만 이번에 고칠 이유가 없어 두었습니다.
- **`spec/5-TESTING.md`는 이슈에 없던 파일입니다.** 테스트 파일이 하나 늘어 §5-1의 수치와 표가 어긋나서 함께 고쳤습니다.

## ✅ 체크리스트

- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요?

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->