### PR TITLE
fix: 팝업 업데이트 안내를 한 줄에 들어가게 줄임

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -85,6 +85,8 @@ header h1 {
   text-decoration: none;
   font-size: 12px;
   margin-left: 8px;
+  /* 헤더가 두 줄로 밀리지 않게 문구 자체는 쪼개지지 않는다. */
+  white-space: nowrap;
 }
 
 .empty-message {

--- a/src/version.js
+++ b/src/version.js
@@ -92,7 +92,10 @@ const VersionManager = {
         updateLink.href = this.getUpdateLink();
         updateLink.target = "_blank";
         updateLink.className = "update-link";
-        updateLink.textContent = `(업데이트 가능: v${latestVersion})`;
+        // 팝업 헤더는 320px 안에서 제목·현재 버전·이 안내를 한 줄에 담아야 한다.
+        // 목표 버전은 링크가 도착하는 스토어 페이지가 이미 보여주므로 title로만 남긴다.
+        updateLink.textContent = "새 업데이트";
+        updateLink.title = `최신 버전 v${latestVersion}`;
         updateMessageEl.replaceChildren(updateLink);
       } else {
         updateMessageEl.textContent = "";


### PR DESCRIPTION
> [!WARNING]
> **Chrome 제출이 끝나기 전에 머지하면 안 됩니다.** #172, #174와 같은 이유입니다.

## 📝 요약

새 버전이 있을 때 팝업 헤더가 두 줄로 밀렸습니다.

```
LinKHU  v2.6.0  (업데이트 가능:
                 v2.7.0)
```

팝업 320px에서 컨테이너 패딩 40px을 빼면 280px이고, 오른쪽 테마·설정 버튼이 약 72px을 씁니다. 남는 폭에 `LinKHU`(20px 굵게) + `v2.6.0` + 저 문구가 함께 들어가지 않습니다.

안내를 **`새 업데이트`**로 줄였습니다.

## ⚙️ 작업 사항

- [x] `src/version.js` — 링크 텍스트를 `새 업데이트`로, 목표 버전은 `title`로 이동
- [x] `src/popup.css` — `.update-link`에 `white-space: nowrap`

## 📌 관련 이슈

- Close #175

## 🧪 테스트 결과

| 명령 | 결과 |
| --- | --- |
| `npm test` | 68 tests / 68 pass / 0 fail |
| `git diff --check` | 출력 없음 |

**수동 검증**: 확장을 v2.6.0으로 로드한 상태에서 팝업을 열어 헤더가 한 줄로 유지되는 것과, 링크에 마우스를 올리면 `최신 버전 v2.7.0`이 뜨는 것을 확인했습니다. 최신 버전을 쓰는 경우 아무것도 표시되지 않는 동작은 그대로입니다.

## 💡 리뷰 포인트

- **버전 번호를 본문에서 뺀 판단.** 목표 버전은 링크가 도착하는 스토어 페이지가 이미 보여주므로 헤더에서 자리를 차지할 이유가 없다고 봤습니다. 대신 `title`에 남겨 정보 자체는 잃지 않습니다. 헤더에서도 보여야 한다면 되돌립니다.
- 현재 버전(`#current-version`)은 그대로 둡니다. 그건 "내가 뭘 쓰고 있나"라 헤더에 있을 이유가 있습니다.

## ✅ 체크리스트

- [x] 이슈를 먼저 만들고 이슈 번호가 포함된 브랜치에서 작업했나요?
- [x] 작업 전 완료 기준과 검증 방법을 정했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 테스트 코드를 작성했거나 수동 테스트를 완료했나요?
- [x] `src/data.js` 변경 시 데이터 검증 결과를 PR 본문에 남겼나요? (데이터 변경 없음)
- [x] 문서(Wiki, API Docs 등)를 업데이트했나요? (해당 없음)

<!-- Gemini Code Assist, please review this PR and write all your comments, summaries, and suggestions in Korean. -->